### PR TITLE
Forbid extra `Trajectory` attributes

### DIFF
--- a/ldp/alg/tree_search.py
+++ b/ldp/alg/tree_search.py
@@ -114,9 +114,7 @@ class TreeSearchRollout(RolloutManager):
             ])
 
             # The original branch plus one step
-            extended_branch = Trajectory(
-                timestep=timestep + 1, traj_id=traj_id, steps=[*branch.steps, step]
-            )
+            extended_branch = Trajectory(traj_id=traj_id, steps=[*branch.steps, step])
 
             if (
                 step.done  # Trajectory is over

--- a/ldp/data_structures.py
+++ b/ldp/data_structures.py
@@ -77,6 +77,8 @@ class Transition(BaseModel):
 
 
 class Trajectory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     traj_id: str | None = None
     steps: list[Transition] = Field(default_factory=list)
 


### PR DESCRIPTION
- For some reason, we were assigning a timestep to a `Trajectory`. Removed it. `_take_step` correctly infers the transition timestep.
- Set `extra='forbid'` to prevent that kind of thing from happening 