### PR TITLE
Accounting for missing typing.override in 3.11

### DIFF
--- a/ldp/graph/pydantic_patch.py
+++ b/ldp/graph/pydantic_patch.py
@@ -1,14 +1,10 @@
 import sys
+from typing import Generic
 
 if sys.version_info >= (3, 12):
-    from typing import Generic, override
+    from typing import override
 else:
-    from typing import Generic
-
-    # python <= 3.11 does not provide typing.override
-    def override(func):
-        return func
-
+    from typing_extensions import override
 
 from pydantic import BaseModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "torch",
     "tqdm",
     "transformers",
+    "typing-extensions; python_version <= '3.11'",  # for typing.override
     "usearch>=2.13",  # For py.typed
 ]
 description = "Agent framework for constructing language model agents and training on constructive tasks."

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "ldp"
-version = "0.1.1.dev1+gc93431d"
+version = "0.1.1.dev3+g33ed669.d20240905"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -962,6 +962,7 @@ dependencies = [
     { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "usearch" },
 ]
 
@@ -1026,6 +1027,7 @@ requires-dist = [
     { name = "transformers" },
     { name = "types-aiofiles", marker = "extra == 'typing'" },
     { name = "types-tqdm", marker = "extra == 'typing'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "usearch", specifier = ">=2.13" },
     { name = "wandb", marker = "extra == 'monitor'" },
 ]


### PR DESCRIPTION
Python 3.11 doesn't have `typing.override`.