### PR TITLE
Running CI `lint` and `pre-commit` on both min/max Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,21 +9,29 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' # pre-commit-ci/lite-action only runs here
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: ${{ matrix.python-version }}
       - uses: pre-commit/action@v3.0.1
       - uses: pre-commit-ci/lite-action@v1.0.2
         if: always()
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run: uv sync
+        run: |-
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv python install ${{ matrix.python-version }}
+      - run: uv sync --python-preference=only-managed
       - run: uv run refurb ldp tests
       - run: uv run pylint ldp tests
   test:


### PR DESCRIPTION
https://github.com/Future-House/ldp/pull/6 exposed the need to defend against version incompatibilities between our min and max Python versions