### PR TITLE
Remove `transformers` and make `torch` optional

### DIFF
--- a/ldp/graph/async_torch.py
+++ b/ldp/graph/async_torch.py
@@ -8,9 +8,15 @@ from contextlib import nullcontext
 from typing import Any
 from uuid import UUID, uuid4
 
-import torch
-from torch import nn
-from torch.utils.data import default_collate
+try:
+    import torch
+    from torch import nn
+    from torch.utils.data import default_collate
+except ImportError:
+    raise ImportError(
+        "ldp.graph.async_torch requires PyTorch as a dependency. "
+        "Please run `pip install ldp[nn]`."
+    ) from None
 
 _TORCH_LOCK = asyncio.Lock()
 

--- a/ldp/graph/torch_ops.py
+++ b/ldp/graph/torch_ops.py
@@ -2,8 +2,14 @@ import inspect
 from collections.abc import Mapping, Sequence
 from typing import Any, ClassVar
 
-import torch
-from torch import nn
+try:
+    import torch
+    from torch import nn
+except ImportError:
+    raise ImportError(
+        "ldp.graph.torch_ops requires PyTorch as a dependency. "
+        "Please run `pip install ldp[nn]`."
+    ) from None
 
 from ldp.graph.async_torch import async_protect_torch_call
 from ldp.graph.op_utils import CallID, get_call_id, get_training_mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "pydantic~=2.0",
     "tenacity",
     "tiktoken",
-    "torch",
     "tqdm",
     "typing-extensions; python_version <= '3.11'",  # for typing.override
     "usearch>=2.13",  # For py.typed
@@ -40,6 +39,9 @@ requires-python = ">=3.11"
 [project.optional-dependencies]
 monitor = [
     "wandb",
+]
+nn = [
+    "torch>=2.2",
 ]
 server = [
     "fastapi>=0.109",  # For Python 3.12 support
@@ -396,7 +398,7 @@ dev-dependencies = [
     "codeflash",
     "fhaviary[xml]",
     "ipython>=8",  # Pin to keep recent
-    "ldp[monitor,server,typing,visualization]",
+    "ldp[monitor,nn,server,typing,visualization]",
     "litellm>=1.40.9,<=1.40.12",  # Pin lower for get_supported_openai_params not requiring custom LLM, upper for https://github.com/BerriAI/litellm/issues/4032
     "mypy>=1.8",  # Pin for mutable-override
     "pre-commit~=3.4",  # Pin to keep recent

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "ldp"
-version = "0.1.1.dev3+g3967e98.d20240905"
+version = "0.1.1.dev4+ga301aab.d20240905"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -959,7 +959,6 @@ dependencies = [
     { name = "pydantic" },
     { name = "tenacity" },
     { name = "tiktoken" },
-    { name = "torch" },
     { name = "tqdm" },
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "usearch" },
@@ -968,6 +967,9 @@ dependencies = [
 [package.optional-dependencies]
 monitor = [
     { name = "wandb" },
+]
+nn = [
+    { name = "torch" },
 ]
 server = [
     { name = "fastapi" },
@@ -1001,6 +1003,7 @@ dev = [
     { name = "pytest-timer", extra = ["colorama"] },
     { name = "pytest-xdist" },
     { name = "refurb" },
+    { name = "torch" },
     { name = "types-aiofiles" },
     { name = "types-tqdm" },
     { name = "wandb" },
@@ -1021,7 +1024,7 @@ requires-dist = [
     { name = "pydot", marker = "extra == 'visualization'", specifier = "~=2.0" },
     { name = "tenacity" },
     { name = "tiktoken" },
-    { name = "torch" },
+    { name = "torch", marker = "extra == 'nn'", specifier = ">=2.2" },
     { name = "tqdm" },
     { name = "types-aiofiles", marker = "extra == 'typing'" },
     { name = "types-tqdm", marker = "extra == 'typing'" },
@@ -1036,7 +1039,7 @@ dev = [
     { name = "codeflash" },
     { name = "fhaviary", extras = ["xml"] },
     { name = "ipython", specifier = ">=8" },
-    { name = "ldp", extras = ["monitor", "server", "typing", "visualization"] },
+    { name = "ldp", extras = ["monitor", "nn", "server", "typing", "visualization"] },
     { name = "litellm", specifier = ">=1.40.9,<=1.40.12" },
     { name = "mypy", specifier = ">=1.8" },
     { name = "pre-commit", specifier = "~=3.4" },


### PR DESCRIPTION
Slimming down dependencies by:
- Removing `transformers`
- Making `torch` a lazy import

To install torch dependencies, specify the extra `ldp[nn]`.