### PR TITLE
Enabling measurement of `failures` using `ComputeTrajectoryMetricsMixin`

### DIFF
--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -227,6 +227,7 @@ class ComputeTrajectoryMetricsMixin:
                 for traj in trajectories
             ],
             "num_steps": [len(traj.steps) for traj in trajectories],
+            "failures": [traj.failed for traj in trajectories],
         }
 
 


### PR DESCRIPTION
This helps us paint a richer overall picture