### PR TITLE
[Fix] Avoid torch requirement

### DIFF
--- a/ldp/graph/gradient_estimators.py
+++ b/ldp/graph/gradient_estimators.py
@@ -178,7 +178,7 @@ class TorchParamBackwardEstimator:
         if torch is None:
             raise RuntimeError(
                 f"PyTorch library not found. Unable to use {type(self).__name__} class. "
-                "To install PyTorch dependencies, please run `pip install 'ldp[nn]'`"
+                "To install PyTorch dependencies, please run `pip install ldp[nn]`."
             )
         self.params = dict(module.named_parameters())
 


### PR DESCRIPTION
Makes a torch lazy import and raises an error in the TorchParamBackwardEstimator class if torch is not found