### PR TITLE
Testing `mmkal/runovate` for batched Renovate

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -1,0 +1,10 @@
+name: deps-sync
+on:
+  push:
+    branches: [main, deps]
+
+jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/deps.yml
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mmkal/runovate@676a208cba11fc44d3e06177e64f4601ae05f340


### PR DESCRIPTION
As of today in this repo, Renovate has three pending schedules:

- Updating GitHub Actions
- Updating `pydot`
- Lock file maintenance

It's annoying to manually approve three PRs. https://github.com/renovatebot/renovate/issues/4404 is an outstanding issue to "roll up" changes into one big PR.

https://github.com/renovatebot/renovate/issues/4404#issuecomment-2200559885 is a solution, which currently looks like this: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/deps.yml.

This PR tests this out