### PR TITLE
Moving to `runovate` that doesn't require `package.json`

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -7,4 +7,5 @@ jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/dep
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: mmkal/runovate@676a208cba11fc44d3e06177e64f4601ae05f340
+      # TODO: move back to mmkal/runovate after https://github.com/mmkal/runovate/pull/5
+      - uses: jamesbraza/runovate@18436286bece110429f7d52e76082b48e3ee4744


### PR DESCRIPTION
Working around https://github.com/mmkal/runovate/issues/4