### PR TITLE
Only running `push`on `main` or `renovate/*` branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Lint and Test
 
 on:
   push:
+    branches:
+      - main
+      - renovate/*
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
I realize https://github.com/Future-House/ldp/pull/52's removal of `push` filter from `main` will lead to CI running on all pushes. Thus, I brought it back, and instead added `renovate/*` branches to the list