### PR TITLE
Allowing runovate to `git push`

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -13,5 +13,4 @@ jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/dep
       # TODO: return to mmkal/runovate after:
       # - https://github.com/mmkal/runovate/pull/5
       # - https://github.com/mmkal/runovate/pull/8
-      # - https://github.com/mmkal/runovate/pull/10
-      - uses: jamesbraza/runovate@dd0d3cdc7b5cf2d709b56456297afde60ca628ce
+      - uses: jamesbraza/runovate@4aac8ab5e9e724cc0de7741e9e808eeed3df5719


### PR DESCRIPTION
From [this CI run](https://github.com/Future-House/ldp/actions/runs/11024127312/job/30616871520):

```none
 ! [remote rejected] deps -> deps (refusing to allow a GitHub App to create or update workflow `.github/workflows/tests.yml` without `workflows` permission)
```

This is because the action tried to `git push`. 