### PR TITLE
Using `actions` over `contents` to allow `git push`

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -4,7 +4,7 @@ on:
     branches: [main, deps]
 
 permissions:
-  contents: write # Allowing runovate to git push
+  actions: write # Allowing runovate to git push
 
 jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/deps.yml
   run:


### PR DESCRIPTION
The fix in https://github.com/Future-House/ldp/pull/55 did not work, the issue persists ([CI run](https://github.com/Future-House/ldp/actions/runs/11026228223/job/30622414737)).

I am now trying this solution: https://github.com/orgs/community/discussions/35410#discussioncomment-7398917