### PR TITLE
Giving `contents: write` permissions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   actions: write # Allowing runovate to git push
+  contents: write # Allowing github.rest.git.createRef
 
 jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/deps.yml
   run:


### PR DESCRIPTION
Now that https://github.com/Future-House/ldp/pull/56 is merged, we get a new failure ([CI run](https://github.com/Future-House/ldp/actions/runs/11026297139/job/30622617666)):

```none
    data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/branches/branches#get-a-branch',
      status: '403'
    }
```

Inspired by https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference, I am trying a solution