### PR TITLE
Removed unnecessary `permissions` from `deps` CI

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -3,10 +3,6 @@ on:
   push:
     branches: [main, deps]
 
-permissions:
-  actions: write # Allowing runovate to git push
-  contents: write # Allowing github.rest.git.createRef
-
 jobs: # SEE: https://github.com/mmkal/trpc-cli/blob/v0.5.1/.github/workflows/deps.yml
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/Future-House/ldp/pull/57 fixed the 403 error but also revealed https://github.com/Future-House/ldp/pull/55 and https://github.com/Future-House/ldp/pull/56 didn't actually solve the underlying issue. The underlying issue is https://github.com/mmkal/runovate/issues/12.

Thus, this PR removes the unnecessarily added `permissions` changes