### PR TITLE
Handling div0 error in `WandBLoggingCallback`

### DIFF
--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -369,7 +369,7 @@ class WandBLoggingCallback(TrajectoryMetricsCallback):
             return
 
         wandb.log({
-            f"eval/{key}_mean": sum(vals) / len(vals)
+            f"eval/{key}_mean": (sum(vals) / len(vals) if vals else None)
             for key, vals in self._eval_metrics.items()
         })
 


### PR DESCRIPTION
See PR title