### PR TITLE
Fixing publish CI

### DIFF
--- a/.github/workflows/codeflash.yml
+++ b/.github/workflows/codeflash.yml
@@ -33,9 +33,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up uv
-        if: steps.bot_check.outputs.skip_remaining_steps == 'no'
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - if: steps.bot_check.outputs.skip_remaining_steps == 'no'
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
       - if: steps.bot_check.outputs.skip_remaining_steps == 'no'
         run: uv sync
       - if: steps.bot_check.outputs.skip_remaining_steps == 'no'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
       - run: uv sync
       - name: Build a binary wheel and a source tarball
         run: uv build --sdist --wheel --out-dir dist/ .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,10 +30,10 @@ jobs:
         python-version: [3.11, 3.12] # Our min and max supported Python versions
     steps:
       - uses: actions/checkout@v4
-      - name: Set up uv
-        run: |-
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv python pin ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - run: uv python pin ${{ matrix.python-version }}
       - run: uv sync --python-preference=only-managed
       - run: uv run refurb ldp tests
       - run: uv run pylint ldp tests
@@ -41,8 +41,9 @@ jobs:
     runs-on: large-runner
     steps:
       - uses: actions/checkout@v4
-      - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
       - run: uv sync
       - run: uv run pytest -n 16 --dist=loadfile # auto only launches 8 workers in CI, despite runners have 16 cores
         env:


### PR DESCRIPTION
- Trying `UV_PUBLISH_TOKEN` over `UV_PUBLISH_PASSWORD` per [this CI failure](https://github.com/Future-House/ldp/actions/runs/11244416198/job/31262434850)
- Moved to `setup-uv`