### PR TITLE
Exposing `Dataset` in `Callback.before_eval_loop`

### DIFF
--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -108,7 +108,7 @@ class Callback:
     async def after_train_step(self, trajectories: Sequence[Trajectory]) -> None:
         """Invoked by OnlineTrainer after each training step."""
 
-    async def before_eval_loop(self) -> None:
+    async def before_eval_loop(self, dataset: TaskDataset) -> None:
         """Invoked by Evaluator and OnlineTrainer before the evaluation loop."""
 
     async def after_eval_step(self, trajectories: Sequence[Trajectory]) -> None:

--- a/ldp/alg/runners.py
+++ b/ldp/alg/runners.py
@@ -30,7 +30,9 @@ async def _run_eval_loop(
     shuffle: bool = False,
     num_rollouts_per_env: int = 1,
 ) -> None:
-    await asyncio.gather(*[callback.before_eval_loop() for callback in callbacks])
+    await asyncio.gather(*[
+        callback.before_eval_loop(dataset) for callback in callbacks
+    ])
 
     if num_iterations is None:
         try:


### PR DESCRIPTION
This PR lets callers access the `TaskDataset` to extract meaningful attributes