### PR TITLE
Pinned llm client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "aiofiles",
     "dm-tree",
-    "fh-llm-client>=0.0.6", #TODO: Remove this pin in future
+    "fh-llm-client>=0.0.6",  # TODO: Remove this pin in future
     "fhaviary>=0.8.2",  # For core namespace
     "httpx",
     "networkx[default]~=3.4",  # Pin for pydot fix

--- a/uv.lock
+++ b/uv.lock
@@ -1182,7 +1182,7 @@ wheels = [
 
 [[package]]
 name = "ldp"
-version = "0.14.4.dev26+gc677c6b.d20241211"
+version = "0.14.4.dev23+g36ae440.d20241216"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1317,7 +1317,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "dm-tree" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.109" },
-    { name = "fh-llm-client" },
+    { name = "fh-llm-client", specifier = ">=0.0.6" },
     { name = "fhaviary", specifier = ">=0.8.2" },
     { name = "fhaviary", extras = ["xml"], marker = "extra == 'dev'" },
     { name = "httpx" },


### PR DESCRIPTION
This PR pins the `fh-llm-client` version.

When installing ldp on downstream repos (issue found in `aviary-internal`), uv is installing version 0.0.1. This PR makes `ldp` require at least version 0.0.6