### PR TITLE
Renovate `lockFileMaintenance` respecting `schedule`, 2-week stability period, no `openai` pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,11 +27,6 @@
       automerge: true,
     },
     {
-      // Allow 'widen' range strategy while matching aviary_internal pyproject.toml
-      matchPackageNames: ["openai"],
-      allowedVersions: "<1.47",
-    },
-    {
       // TODO: remove after torch supports Python 3.13
       matchPackageNames: ["python"],
       allowedVersions: "<=3.12",


### PR DESCRIPTION
- Accounts for https://github.com/renovatebot/renovate/discussions/33152 in `lockFileMaintenance`
- Added a two-week stability period to deps so Renovate avoids hotfixes
- https://github.com/Future-House/ldp/pull/148 missed removing `openai` downpinning from Renovate