### PR TITLE
Fix callback file opening

### DIFF
--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -173,7 +173,7 @@ class TrajectoryFileCallback(Callback):
         # TODO: make this async?
         traj.to_jsonl(self.out_files[traj_id])
         if transition.done:
-            with Path(self.env_files[traj_id]).open() as f:
+            with Path(self.env_files[traj_id]).open("w") as f:
                 f.write(env.export_frame().model_dump_json(exclude={"state"}, indent=2))
 
 


### PR DESCRIPTION
Was crashing for me:
```
  File "/code/ldp/ldp/alg/callbacks.py", line 176, in after_transition
    with Path(self.env_files[traj_id]).open() as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.12.8-linux-x86_64-gnu/lib/python3.12/pathlib.py", line 1013, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/sid/aviary_data/sid/seqqa-local-tsft/v4/eval/v1/seqqa_sid-seqqa-local-tsft-v4-training-v1-epoch-5-ckpt_SimpleLocalLLMAgent_0/adcc236a09464241a1512ff0326309d2_env.json'
```