### PR TITLE
`Agent.get_as` as an alternative to `get_asv`

### DIFF
--- a/ldp/agent/interactive_agent.py
+++ b/ldp/agent/interactive_agent.py
@@ -45,9 +45,9 @@ class InteractiveAgent(Agent[SimpleAgentState]):
         return SimpleAgentState(tools=tools)
 
     @compute_graph()
-    async def get_asv(  # noqa: C901
+    async def get_as(  # noqa: C901
         self, agent_state: SimpleAgentState, obs: list[Message]
-    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState]:
         print()  # add a newline to flush any progress bars, etc
         print("OBSERVATIONS:\n" + ("-" * 80))
         for msg in obs:
@@ -80,7 +80,7 @@ class InteractiveAgent(Agent[SimpleAgentState]):
             while True:
                 value = input(prompt)
                 if value == CLEAR:
-                    return await self.get_asv(agent_state, obs)  # just start over
+                    return await self.get_as(agent_state, obs)  # just start over
                 if value == EXIT:
                     raise RuntimeError("User requested to kill the agent.")
 
@@ -108,7 +108,7 @@ class InteractiveAgent(Agent[SimpleAgentState]):
 
         next_agent_state.messages = [*next_agent_state.messages, action.value]
 
-        return action, next_agent_state, 0.0
+        return action, next_agent_state
 
     @staticmethod
     def _get_param_string(pname: str, pprops: dict[str, Any]) -> str:

--- a/ldp/agent/memory_agent.py
+++ b/ldp/agent/memory_agent.py
@@ -103,9 +103,9 @@ class MemoryAgent(SimpleAgent):
         self._package_op = FxnOp(self._package_messages)
 
     @compute_graph()
-    async def get_asv(
+    async def get_as(
         self, agent_state: SimpleAgentState, obs: list[Message]
-    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState]:
         next_state = agent_state.get_next_state(obs)
 
         memories = await self._memory_op(
@@ -126,4 +126,4 @@ class MemoryAgent(SimpleAgent):
             ),
         )
         next_state.messages = [*next_state.messages, result.value]
-        return result, next_state, 0.0
+        return result, next_state

--- a/ldp/agent/react_agent.py
+++ b/ldp/agent/react_agent.py
@@ -165,9 +165,9 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
         retry_error_callback=after_retry_failure_log,
     )
     @compute_graph()
-    async def get_asv(
+    async def get_as(
         self, agent_state: SimpleAgentState, obs: list[Message]
-    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState]:
         obs = obs.copy()  # Keep original obs, as we edit the content below
         if self.single_prompt:
             for i, m in enumerate(obs):
@@ -184,4 +184,4 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
             messages=next_state.messages, tools=next_state.tools
         )
         next_state.messages = [*next_state.messages, *new_messages]
-        return action_selection_result, next_state, 0.0
+        return action_selection_result, next_state

--- a/ldp/agent/simple_agent.py
+++ b/ldp/agent/simple_agent.py
@@ -115,9 +115,9 @@ class SimpleAgent(BaseModel, Agent[SimpleAgentState]):
         )
 
     @compute_graph()
-    async def get_asv(
+    async def get_as(
         self, agent_state: SimpleAgentState, obs: list[Message]
-    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState]:
         next_state = agent_state.get_next_state(obs)
 
         messages = (
@@ -132,4 +132,4 @@ class SimpleAgent(BaseModel, Agent[SimpleAgentState]):
             ),
         )
         next_state.messages = [*next_state.messages, result.value]
-        return result, next_state, 0.0
+        return result, next_state

--- a/ldp/agent/tree_of_thoughts_agent.py
+++ b/ldp/agent/tree_of_thoughts_agent.py
@@ -73,14 +73,14 @@ class TreeofThoughtsAgent(BaseModel, Agent[SimpleAgentState]):
         )
 
     @compute_graph()
-    async def get_asv(  # type: ignore[override]
+    async def get_as(  # type: ignore[override]
         self,
         agent_state: SimpleAgentState,
         obs: list[Message],
         eval_function: Callable[[str, list[str]], float],
         n_steps: int = 0,
         n_select_samples: int = 0,
-    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], SimpleAgentState]:
         """Generate and evaluate possible steps in the problem-solving process.
 
         Args:
@@ -149,4 +149,4 @@ class TreeofThoughtsAgent(BaseModel, Agent[SimpleAgentState]):
                 op_class_name=type(self).__name__,
                 value=result,
             )
-        return op_result, new_state, 0.0
+        return op_result, new_state

--- a/tests/test_algorithms.py
+++ b/tests/test_algorithms.py
@@ -27,7 +27,7 @@ async def test_rollout_and_discounting(dummy_env: DummyEnv) -> None:
             agent_state = await agent.init_state(tools=tools)
 
         observations.append((obs, agent_state))
-        action, agent_state, _ = await agent.get_asv(agent_state, obs)
+        action, agent_state = await agent.get_as(agent_state, obs)
         obs, reward, done, _ = await dummy_env.step(action.value)
         actions.append(action)
         rewards.append(reward)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -93,7 +93,7 @@ class TestParallelism:
         agent = SimpleAgent()
 
         # Check parallel tool calls
-        action, agent_state, _ = await agent.get_asv(
+        action, agent_state = await agent.get_as(
             await agent.init_state(tools=tools), obs
         )
         selected_tools: set[str] = {tc.function.name for tc in action.value.tool_calls}

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -187,12 +187,12 @@ class CountingAgent(Agent[CountingAgentState]):
         return CountingAgentState()
 
     @compute_graph()
-    async def get_asv(
+    async def get_as(
         self, agent_state: CountingAgentState, obs: list[Message]
-    ) -> tuple[OpResult[ToolRequestMessage], CountingAgentState, float]:
+    ) -> tuple[OpResult[ToolRequestMessage], CountingAgentState]:
         new_state = CountingAgentState(count=float(cast(str, obs[0].content)) + 1)
         action = await self.op()
-        return action, new_state, 0.0
+        return action, new_state
 
 
 class CountingEnv(Environment[float]):


### PR DESCRIPTION
I wanted to see what this `Agent.get_as` looks like since we've discussed it before. This PR's motivation is:
- Right now no agent in LDP estimate value
- Most unit tests (aka simple scripts) discard value

Pros:
- Simplicity/one less piece of information to comprehend for basic `Agent` implementations

Cons:
- Introduces room for ambiguity in runner code
- Introduces possible necessity for duplication across `get_as` and `get_asv`
- `get_as` is confusing because "as" is actually an English word, whereas "asv" is not
    - If you read as "get as" instead of "get action state" at first glance it's confusing