### PR TITLE
Better HTTP Error Handling

### DIFF
--- a/ldp/alg/rollout.py
+++ b/ldp/alg/rollout.py
@@ -10,6 +10,7 @@ from aviary.core import Environment, Message
 
 from ldp.agent import Agent
 from ldp.data_structures import Trajectory, Transition
+from ldp.utils import format_error_details
 
 from .callbacks import Callback
 
@@ -42,19 +43,7 @@ def reraise_exc_as(reraise: type[CaughtError], enabled: bool) -> Iterator[None]:
         yield
     except Exception as e:
         if enabled:
-            # Add more detailed error information
-            error_details = f"{e!s}"
-            if hasattr(e, "response"):  # For HTTP errors
-                error_details += f"\nStatus code: {e.response.status_code}"
-                try:
-                    response_data = e.response.json()
-                    if "detail" in response_data:
-                        error_details += "\nServer Traceback:\n"
-                        for line in response_data["detail"].split("\n"):
-                            error_details += f"    {line}\n"
-                except Exception:
-                    error_details += f"\nResponse body: {e.response.text}"
-
+            error_details = format_error_details(e)
             logger.exception(f"Caught {reraise.exc_type} exception:\n{error_details}")
             raise reraise(e) from None
         raise

--- a/ldp/utils.py
+++ b/ldp/utils.py
@@ -2,6 +2,8 @@ import logging
 import logging.config
 from typing import Any
 
+logger = logging.getLogger(__name__)
+
 
 def configure_stdout_logs(
     name: str = "root",
@@ -80,3 +82,31 @@ def discounted_returns(
         returns.append(r)
     returns.reverse()
     return returns
+
+
+def format_error_details(error: Exception) -> str:
+    """Format detailed error information from an exception.
+
+    Specially handles HTTP errors that have response attributes with status codes
+    and JSON details, but works with any exception type.
+
+    Args:
+        error: The exception to format
+
+    Returns:
+        A formatted error string with available details
+    """
+    error_details = f"{error!s}"
+
+    if hasattr(error, "response"):
+        error_details += f"\nStatus code: {error.response.status_code}"
+        try:
+            response_data = error.response.json()
+            if "detail" in response_data:
+                error_details += "\nServer Traceback:\n"
+                for line in response_data["detail"].split("\n"):
+                    error_details += f"    {line}\n"
+        except Exception:
+            error_details += f"\nResponse body: {error.response.text}"
+
+    return error_details

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+from typing import Any
+
+from ldp.utils import format_error_details
+
+
+@dataclass
+class MockResponse:
+    status_code: int
+    _json: dict | None = None
+    _text: str = ""
+
+    def json(self) -> dict[str, Any]:
+        if self._json is None:
+            raise ValueError("No JSON")
+        return self._json
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+
+class MockHTTPError(Exception):
+    def __init__(self, status_code: int, detail: str | None = None, text: str = ""):
+        self.response = MockResponse(
+            status_code=status_code,
+            _json={"detail": detail} if detail else None,
+            _text=text,
+        )
+        super().__init__(f"HTTP {status_code}")
+
+
+def test_format_basic_error():
+    error = ValueError("something went wrong")
+    details = format_error_details(error)
+    assert details == "something went wrong"
+
+
+def test_format_http_error_with_json():
+    error = MockHTTPError(
+        status_code=500,
+        detail="Traceback:\n  File 'app.py', line 123\n  raise ValueError('oops')",
+    )
+    details = format_error_details(error)
+    assert "Status code: 500" in details
+    assert "Server Traceback:" in details
+    assert "File 'app.py'" in details
+
+
+def test_format_http_error_with_text():
+    error = MockHTTPError(status_code=404, text="Not found")
+    details = format_error_details(error)
+    assert "Status code: 404" in details
+    assert "Response body: Not found" in details


### PR DESCRIPTION
Currently, when we run a rollout and the environment fails, the reason for failure is not included in the traceback. Instead we get the following unhelpful traceback

```
Traceback (most recent call last):
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 42, in reraise_exc_as
    yield
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 229, in _rollout
    obs, tools = await env.reset()
                 ^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 102, in reset
    return await super().reset()
           ^^^^^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 46, in reset
    response = await self._post(
               ^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 42, in _post
    response.raise_for_status()
  File "aviary-internal/.venv/lib/python3.12/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:8080/reset'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
Traceback (most recent call last):               
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 42, in reraise_exc_as
    yield
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 229, in _rollout
    obs, tools = await env.reset()
                 ^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 102, in reset
    return await super().reset()
           ^^^^^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 46, in reset
    response = await self._post(
               ^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/aviary/env_client.py", line 42, in _post
    response.raise_for_status()
  File "aviary-internal/.venv/lib/python3.12/site-packages/httpx/_models.py", line 763, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Server error '500 Internal Server Error' for url 'http://localhost:8080/reset'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 228, in _rollout
    with reraise_exc_as(EnvError, enabled=self.catch_env_failures):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 46, in reraise_exc_as
    raise reraise(e) from e
ldp.alg.rollout.EnvError: Server error '500 Internal Server Error' for url 'http://localhost:8080/reset'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

Traceback (most recent call last):
  File "aviary-internal/.venv/bin/run_expt", line 8, in <module>
    sys.exit(_run_expt())
             ^^^^^^^^^^^
  File "aviary-internal/aviary_internal/utils/configurable.py", line 92, in _run_expt
    asyncio.run(expt.run())
  File ".local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File ".local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "aviary-internal/envs/data-analysis/data_analysis/expts/eval.py", line 112, in run
    await evaluator.run()
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/runners.py", line 143, in run
    await _run_eval_loop(
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/runners.py", line 55, in _run_eval_loop
    trajectories = await rollout_manager.sample_trajectories(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 125, in sample_trajectories
    return await self._sample_trajectories_from_envs(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 196, in _sample_trajectories_from_envs
    await asyncio.gather(
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 261, in _rollout
    await store_step(
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 213, in store_step
    await asyncio.gather(*[
  File "aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/callbacks.py", line 170, in after_transition
    assert traj_id in self.out_files

```

**Proposed changes**
I've updated the error handling for http responses to include the reason for env failure at the top of the traceback:

```
2024-12-30 15:05:55,479 - ldp.alg.rollout - ERROR - Caught env exception:
Server error '500 Internal Server Error' for url 'http://localhost:8080/reset'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
Status code: 500
Server Traceback:
    Traceback (most recent call last):
      File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/aviary/dataset_server.py", line 216, in handle_exc_as_http_exc
        yield
      File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/aviary/dataset_server.py", line 123, in reset
        obs, tools = await env.reset()
                     ^^^^^^^^^^^^^^^^^
      File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/envs/data-analysis/data_analysis/env.py", line 72, in reset
        fake = error
               ^^^
    NameError: name 'error' is not defined
    
Traceback (most recent call last):               
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 243, in _rollout
    with reraise_exc_as(EnvError, enabled=self.catch_env_failures):
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 61, in reraise_exc_as
    raise reraise(e) from None
ldp.alg.rollout.EnvError: Server error '500 Internal Server Error' for url 'http://localhost:8080/reset'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/bin/run_expt", line 8, in <module>
    sys.exit(_run_expt())
             ^^^^^^^^^^^
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/aviary_internal/utils/configurable.py", line 92, in _run_expt
    asyncio.run(expt.run())
  File "/Users/ludovicomitchener/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/envs/data-analysis/data_analysis/expts/eval.py", line 112, in run
    await evaluator.run()
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/runners.py", line 143, in run
    await _run_eval_loop(
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/runners.py", line 55, in _run_eval_loop
    trajectories = await rollout_manager.sample_trajectories(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 140, in sample_trajectories
    return await self._sample_trajectories_from_envs(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 211, in _sample_trajectories_from_envs
    await asyncio.gather(
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 283, in _rollout
    await store_step(
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/rollout.py", line 228, in store_step
    await asyncio.gather(*[
  File "/Users/ludovicomitchener/Desktop/repos/aviary-internal/.venv/lib/python3.12/site-packages/ldp/alg/callbacks.py", line 170, in after_transition
    assert traj_id in self.out_files
```
