### PR TITLE
Consolidating `StoreTrajectoriesCallback` with `TrajectoryFileCallback`, `async` file I/O, controlling env dump

### DIFF
--- a/ldp/alg/__init__.py
+++ b/ldp/alg/__init__.py
@@ -8,7 +8,6 @@ from .callbacks import (
     MeanMetricsCallback,
     RolloutDebugDumpCallback,
     StoreTrajectoriesCallback,
-    TrajectoryFileCallback,
     TrajectoryMetricsCallback,
     WandBLoggingCallback,
 )
@@ -41,7 +40,6 @@ __all__ = [
     "RolloutManager",
     "StoreTrajectoriesCallback",
     "TEnvCloneFn",
-    "TrajectoryFileCallback",
     "TrajectoryMetricsCallback",
     "TreeSearchRollout",
     "WandBLoggingCallback",

--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -162,8 +162,7 @@ class TrajectoryFileCallback(Callback):
 
         traj = self.trajs[traj_id]
         traj.steps.append(transition)
-        # TODO: make this async?
-        traj.to_jsonl(self.out_files[traj_id])
+        await traj.to_jsonl(self.out_files[traj_id])
         if transition.done:
             with (
                 # Do not fail if the environment didn't implement export_frame().

--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -134,7 +134,7 @@ class StoreTrajectoriesCallback(Callback):
             frame = env.export_frame()
         except NotImplementedError:
             return None  # Allow for envs that didn't implement export_frame()
-        return frame.model_dump_json(exclude={"state"}, indent=2)
+        return frame.model_dump_json(indent=2)
 
     def __init__(
         self,

--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -172,9 +172,9 @@ class StoreTrajectoriesCallback(Callback):
         traj.steps.append(transition)
         if self.output_dir is not None:
             await traj.to_jsonl(self.traj_files[traj_id])
-            with self.env_files[traj_id].open("w") as f:
+            async with aiofiles.open(self.env_files[traj_id], "w") as f:
                 if to_dump := self.serialize_env(env, transition):
-                    f.write(to_dump)
+                    await f.write(to_dump)
 
     async def after_train_step(self, trajectories: Sequence[Trajectory]) -> None:
         self.train_traj_ids.extend([t.traj_id for t in trajectories])

--- a/ldp/data_structures.py
+++ b/ldp/data_structures.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from typing import Any, ClassVar, Self, cast
 from uuid import UUID
 
+import aiofiles
 import networkx as nx
 from aviary.core import Message, ToolRequestMessage, ToolResponseMessage, join
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
@@ -111,10 +112,11 @@ class Trajectory(BaseModel):
             return False
         return self.steps[-1].done
 
-    def to_jsonl(self, filename: str | os.PathLike) -> None:
-        with open(filename, "w") as f:
-            f.write(json.dumps(self.traj_id) + "\n")
-            f.writelines(s.model_dump_json() + "\n" for s in self.steps)
+    async def to_jsonl(self, filename: str | os.PathLike) -> None:
+        async with aiofiles.open(filename, "w") as f:
+            await f.write(json.dumps(self.traj_id) + "\n")
+            for s in self.steps:
+                await f.write(s.model_dump_json() + "\n")
 
     @classmethod
     def from_jsonl(cls, filename: str | os.PathLike) -> Self:

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -75,7 +75,7 @@ async def test_rollout(training: bool) -> None:
     # Let's check we can serialize and deserialize the trajectories
     for traj in trajs:
         with tempfile.NamedTemporaryFile(suffix=".jsonl") as f:
-            traj.to_jsonl(filename=f.name)
+            await traj.to_jsonl(filename=f.name)
             rehydrated_traj = Trajectory.from_jsonl(f.name)
             assert traj.traj_id == rehydrated_traj.traj_id
 

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -149,7 +149,7 @@ async def test_offline_trainer(clear_ctx_at_each_iter: bool) -> None:
         callbacks=[traj_callback],
     )
     await evaluator.run()
-    assert len(traj_callback.eval_trajectories) == 1
+    assert len(traj_callback.eval_traj_ids) == 1
 
     count_callback = DummyCallback()
     metrics_callback = MeanMetricsCallback(train_dataset=dataset)
@@ -160,7 +160,11 @@ async def test_offline_trainer(clear_ctx_at_each_iter: bool) -> None:
         ),
         agent=agent,
         optimizer=opt,
-        train_trajectories=traj_callback.eval_trajectories,
+        train_trajectories=[
+            traj_callback.traj_id_to_traj[t_id]
+            for t_id in traj_callback.eval_traj_ids
+            if t_id
+        ],
         callbacks=[count_callback, metrics_callback],
     )
     await trainer.train()


### PR DESCRIPTION
This PR:
- Consolidates `TrajectoryFileCallback` into `StoreTrajectoriesCallback` with optional files
- Allows for control over `Environment.Frame` dump
- Dumps all files in `async` via `aiofiles`, resolving a TODO comment