### PR TITLE
`TrajectoryFileCallback` having `async` file I/O and controlling `Environment` dump

### DIFF
--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -162,8 +162,7 @@ class TrajectoryFileCallback(Callback):
 
         traj = self.trajs[traj_id]
         traj.steps.append(transition)
-        # TODO: make this async?
-        traj.to_jsonl(self.out_files[traj_id])
+        await traj.to_jsonl(self.out_files[traj_id])
         if transition.done:
             with (
                 # Do not fail if the environment didn't implement export_frame().

--- a/ldp/alg/callbacks.py
+++ b/ldp/alg/callbacks.py
@@ -1,10 +1,10 @@
+import asyncio
 import json
 import logging
 import os
 import time
 from collections import defaultdict
-from collections.abc import Collection, Iterable, Sequence
-from contextlib import suppress
+from collections.abc import Callable, Collection, Iterable, Sequence
 from pathlib import Path
 from typing import Any, cast
 
@@ -139,37 +139,58 @@ class StoreTrajectoriesCallback(Callback):
 class TrajectoryFileCallback(Callback):
     """Callback that writes trajectories to a file."""
 
-    def __init__(self, output_dir: os.PathLike | str):
+    @staticmethod
+    def default_serialize_env(env: Environment, transition: Transition) -> str | None:
+        """Export a JSON-serialized Frame if the transition is done."""
+        if not transition.done:
+            return None
+        try:
+            frame = env.export_frame()
+        except NotImplementedError:
+            return None  # Allow for envs that didn't implement export_frame()
+        return frame.model_dump_json(exclude={"state"}, indent=2)
+
+    def __init__(
+        self,
+        output_dir: str | os.PathLike,
+        serialize_env: Callable[
+            [Environment, Transition], str | None
+        ] = default_serialize_env,
+    ):
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        self.out_files: dict[str, Path] = {}
+        self.traj_files: dict[str, Path] = {}
         self.env_files: dict[str, Path] = {}
         self.trajs: dict[str, Trajectory] = defaultdict(Trajectory)
 
-    def _make_filename(self, traj_id: str, env: Environment) -> str:
+        self.serialize_env = serialize_env
+
+    def _make_traj_filename(self, traj_id: str, env: Environment) -> str:
         """Create the filename for the output file."""
         return f"{traj_id}.jsonl"
 
     async def after_transition(
         self, traj_id: str, agent: Agent, env: Environment, transition: Transition
     ) -> None:
-        if traj_id not in self.out_files:
-            self.out_files[traj_id] = self.output_dir / self._make_filename(
+        if traj_id not in self.traj_files:
+            self.traj_files[traj_id] = self.output_dir / self._make_traj_filename(
                 traj_id, env
             )
             self.env_files[traj_id] = self.output_dir / f"{traj_id}_env.json"
 
         traj = self.trajs[traj_id]
         traj.steps.append(transition)
-        await traj.to_jsonl(self.out_files[traj_id])
-        if transition.done:
-            with (
-                # Do not fail if the environment didn't implement export_frame().
-                suppress(NotImplementedError),
-                Path(self.env_files[traj_id]).open("w") as f,
-            ):
-                f.write(env.export_frame().model_dump_json(exclude={"state"}, indent=2))
+
+        async def possibly_dump_env() -> None:
+            async with aiofiles.open(self.env_files[traj_id], "w") as f:
+                env_or_none = self.serialize_env(env, transition)
+                if env_or_none is not None:
+                    await f.write(env_or_none)
+
+        await asyncio.gather(
+            possibly_dump_env(), traj.to_jsonl(self.traj_files[traj_id])
+        )
 
 
 class RolloutDebugDumpCallback(Callback):

--- a/ldp/data_structures.py
+++ b/ldp/data_structures.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from typing import Any, ClassVar, Self, cast
 from uuid import UUID
 
+import aiofiles
 import networkx as nx
 from aviary.core import Message, ToolRequestMessage, ToolResponseMessage, join
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator
@@ -111,10 +112,11 @@ class Trajectory(BaseModel):
             return False
         return self.steps[-1].done
 
-    def to_jsonl(self, filename: str | os.PathLike) -> None:
-        with open(filename, "w") as f:
-            f.write(json.dumps(self.traj_id) + "\n")
-            f.writelines(s.model_dump_json() + "\n" for s in self.steps)
+    async def to_jsonl(self, filename: str | os.PathLike) -> None:
+        async with aiofiles.open(filename, "w") as f:
+            await f.write(json.dumps(self.traj_id) + "\n")
+            for s in self.steps:
+                await f.write(s.model_dump_json() + "\n")
 
     @classmethod
     def from_jsonl(cls, filename: str | os.PathLike) -> Self:

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -75,7 +75,7 @@ async def test_rollout(training: bool) -> None:
     # Let's check we can serialize and deserialize the trajectories
     for traj in trajs:
         with tempfile.NamedTemporaryFile(suffix=".jsonl") as f:
-            traj.to_jsonl(filename=f.name)
+            await traj.to_jsonl(filename=f.name)
             rehydrated_traj = Trajectory.from_jsonl(f.name)
             assert traj.traj_id == rehydrated_traj.traj_id
 


### PR DESCRIPTION
This PR:
- Dumps all files in `async` via `aiofiles`, resolving a TODO comment
- Allows for control over `Environment.Frame` dump
- Makes attribute names more intuitive