### PR TITLE
LLM response validation

### DIFF
--- a/ldp/graph/common_ops.py
+++ b/ldp/graph/common_ops.py
@@ -307,7 +307,8 @@ class LLMCallOp(Op[Message]):
 
         @tenacity.retry(
             retry=tenacity.retry_if_exception_type(ResponseValidationError),
-            stop=tenacity.stop_after_attempt(num_retries),
+            # num_retries+1 because the first call is not a retry
+            stop=tenacity.stop_after_attempt(num_retries + 1),
             wait=tenacity.wait_fixed(1),
         )
         async def call_and_validate() -> LLMResult:

--- a/ldp/graph/common_ops.py
+++ b/ldp/graph/common_ops.py
@@ -214,6 +214,15 @@ class LLMCallOp(Op[Message]):
         num_samples_logprob_estimate: int = 0,
         response_validator: Callable[[LLMResult], Awaitable[None] | None] | None = None,
     ) -> None:
+        """Initializes the LLMCallOp.
+
+        Args:
+            num_samples_logprob_estimate: The number of samples used to estimate the partition
+                function at T!=1. Defaults to 0 (calculation is skipped).
+            response_validator: An optional callable (can be async) that validates the response.
+                It should raise an exception if the response is invalid. The Op will retry up
+                to `config.get('num_retries', 0)` times if validation fails.
+        """
         super().__init__()
         self.num_samples_partition_estimate = num_samples_logprob_estimate
         self.response_validator = response_validator

--- a/ldp/graph/common_ops.py
+++ b/ldp/graph/common_ops.py
@@ -328,7 +328,7 @@ class LLMCallOp(Op[Message]):
 
             try:
                 validated = cast(Callable, self.response_validator)(result)
-                if is_coroutine_callable(self.response_validator):
+                if inspect.isawaitable(validated):
                     validated = await validated
             except Exception as e:
                 raise ResponseValidationError(

--- a/ldp/graph/common_ops.py
+++ b/ldp/graph/common_ops.py
@@ -418,7 +418,7 @@ class LLMCallOp(Op[Message]):
                 continue
 
             for tc in msg.tool_calls:
-                if any(x in tc.function.name for x in "{}<>"):
+                if any(x in tc.function.name for x in "{}<>()"):
                     err_msg = f"Found bad tool call: {tc}"
                     logger.error(err_msg)
                     raise ValueError(err_msg)

--- a/tests/cassettes/TestLLMCallOp.test_validation.yaml
+++ b/tests/cassettes/TestLLMCallOp.test_validation.yaml
@@ -1,0 +1,106 @@
+interactions:
+  - request:
+      body:
+        '{"messages": [{"role": "user", "content": "Hello"}], "model": "gpt-4o-mini-2024-07-18",
+        "n": 1}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "95"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.59.7
+        x-stainless-arch:
+          - x64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - Linux
+        x-stainless-package-version:
+          - 1.59.7
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xSwY7TMBC95yuGOTcoLV2l7QUhkOhKe4ADEssKRa49SQ2Ox9jOQrXqvyMnbZMK
+          VtpLDu/Ne3lvPE8ZAGqFG0C5F1G2zuTvfr0v17vV/debg/h2t+WPj59UWX6+X3+4+3KLs6Tg3Q+S
+          8ax6Lbl1hqJmO9DSk4iUXOflm7IoFutV2RMtKzJJ1riYLzlvtdX5olgs86LM56uTes9aUsANPGQA
+          AE/9N+W0iv7gBorZGWkpBNEQbi5DAOjZJARFCDpEYSPORlKyjWT76Fsyhl/Bln+DFBZuYRDAgTuI
+          rMTh7VToqe6CSOFtZ8wJP16SGG6c51048Re81laHfeVJBLbpryGyw549ZgDf+8bdVQl0nlsXq8g/
+          ySbD1eCG45pHbn5aBkaOwkzws+jKrFIUhTZhsjCUQu5Jjcpxu6JTmidENqn8b5j/eQ+1tW1eYj8S
+          UpKLpCrnSWl5XXgc85SO8Lmxy4r7wBjIP2pJVdTk0zMoqkVnhtPAcAiR2qrWtiHvvB7uo3ZVuSBV
+          it3NUmJ2zP4CAAD//wMAc2QAgS0DAAA=
+      headers:
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-RAY:
+          - 902b7b21ef9cba21-SEA
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 16 Jan 2025 04:49:48 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=940efh6IXrRBGzKpiScnpcSFSq.Qq5h.tZsG.tFRuXE-1737002988-1.0.1.1-glrn9jp0jJubbYQm1IpaQ0F7.hBwZxBO7pjIgct3Hry182dHr7EMmLLb4RleHEPiSBfV0OrZD33VvlywHYIHwg;
+            path=/; expires=Thu, 16-Jan-25 05:19:48 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=fAwazJ9ZSOYywFdRAWoUeWZsgr45nzOyAHTcLlcUSP0-1737002988356-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "404"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999981"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_0ee9e043e2ad94fb0c69ad10bdbfa73e
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -164,7 +164,7 @@ class TestLLMCallOp:
     async def test_empty_tools(self) -> None:
         llm_call_op = LLMCallOp()
         message_result = await llm_call_op(
-            LLMModel.model_fields["config"].default,
+            LLMModel.model_fields["config"].default_factory(),  # type: ignore[call-arg, misc]
             msgs=[Message(content="Hello")],
             tools=[],
         )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -206,9 +206,10 @@ class StatefulValidator:
     def __init__(self):
         self.counter = 0
 
-    def __call__(self, response: LLMResult) -> bool:
+    def __call__(self, response: LLMResult) -> None:
         self.counter += 1
-        return self.counter > 1
+        if self.counter == 1:
+            raise ValueError("Invalid response")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR implements user-specified response validation for `LLMCallOp` with retries. I've implemented a validator for mangled tool calls from Anthropic, but one could also use this for rejection sampling, etc. 

I toyed around with a couple other places to put this (`llmclient.LiteLLMModel`, `SimpleAgent`), but found this to be most natural and easiest to configure. Ideally I'd have liked to implement this as a `litellm` callback, but I don't think their retry mechanism is triggered by callback exceptions. 