### PR TITLE
Local LLM call arguments

### DIFF
--- a/ldp/nn/agent/simple_local_agent.py
+++ b/ldp/nn/agent/simple_local_agent.py
@@ -45,9 +45,7 @@ class AgentLMConfig(_LMConfig):
     @field_validator("llm_call_kwargs")
     @classmethod
     def validate_llm_call_kwargs(cls, v: dict) -> dict:
-        v.setdefault("top_k", None)
-        v.setdefault("top_p", 1.0)
-        return v
+        return {"top_k": None, "top_p": 1.0} | v
 
 
 # TODO: consider merging with SimpleAgent

--- a/ldp/nn/agent/simple_local_agent.py
+++ b/ldp/nn/agent/simple_local_agent.py
@@ -3,6 +3,7 @@ from typing import cast
 import torch
 import torch.distributed as dist
 from aviary.core import Message, Tool, ToolRequestMessage
+from pydantic import Field, field_validator
 
 from ldp.agent import Agent, SimpleAgentState
 from ldp.graph import OpResult
@@ -32,6 +33,21 @@ class AgentLMConfig(_LMConfig):
     temperature: float = 1.0
     max_new_tokens: int = 50
     parallel_tool_calls: bool = False
+
+    llm_call_kwargs: dict = Field(
+        default_factory=dict,
+        description="Additional kwargs to pass to LocalLLMCallOp.forward. "
+        "Note that the validator defaults top_k=None and top_p=1.0, which "
+        "are better defaults than HF's.",
+        validate_default=True,
+    )
+
+    @field_validator("llm_call_kwargs")
+    @classmethod
+    def validate_llm_call_kwargs(cls, v: dict) -> dict:
+        v.setdefault("top_k", None)
+        v.setdefault("top_p", 1.0)
+        return v
 
 
 # TODO: consider merging with SimpleAgent
@@ -84,6 +100,7 @@ class SimpleLocalLLMAgent(Agent[SimpleAgentState]):
                 temperature=self.llm_model.temperature,
                 max_new_tokens=self.llm_model.max_new_tokens,
                 tools=next_state.tools,
+                **self.llm_model.llm_call_kwargs,
             ),
         )
 

--- a/ldp/nn/generation/__init__.py
+++ b/ldp/nn/generation/__init__.py
@@ -1,0 +1,5 @@
+from .base import LogitsProcessorWithFinalize
+
+__all__ = [
+    "LogitsProcessorWithFinalize",
+]

--- a/ldp/nn/generation/base.py
+++ b/ldp/nn/generation/base.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+
+import torch
+from transformers import LogitsProcessor
+
+
+class LogitsProcessorWithFinalize(LogitsProcessor, ABC):
+    @abstractmethod
+    def finalize(self, token_ids: torch.Tensor) -> None:
+        pass

--- a/ldp/nn/generation/base.py
+++ b/ldp/nn/generation/base.py
@@ -7,4 +7,8 @@ from transformers import LogitsProcessor
 class LogitsProcessorWithFinalize(LogitsProcessor, ABC):
     @abstractmethod
     def finalize(self, token_ids: torch.Tensor) -> None:
-        pass
+        """A method for subclasses to inject arbitrary finalization logic after sampling finishes.
+
+        TransformerHandler will invoke logit_processor.finalize(token_ids), where token_ids are
+        the sampled tokens.
+        """

--- a/ldp/nn/handlers/transformer_handler.py
+++ b/ldp/nn/handlers/transformer_handler.py
@@ -127,8 +127,8 @@ class ParallelModeConfig(FSDPConfig):
     )
     execution_mode: ExecutionMode = Field(
         description=(
-            "Execution mode of the current setup, defines how to allocate resources"
-            " (cpus/gpus) for the model to run on."
+            "Execution mode of the current setup, defines how to allocate resources "
+            "(cpus/gpus) for the model to run on."
         ),
         default=ExecutionMode.LOCAL_MACHINE,
     )
@@ -169,8 +169,8 @@ class TransformerHandlerConfig(BaseModel):
     parallel_mode_config: ParallelModeConfig | None = Field(
         default=None,
         description=(
-            "Opt-in config for parallel execution, default of None leads to a"
-            " transformer without parallelism"
+            "Optional configuration for distributing the transformer across "
+            "multiple devices/nodes. If not provided, will default to single-device."
         ),
     )
 


### PR DESCRIPTION
Missed a couple things in #217 :
- Ability to pass in arbitrary call kwargs
- Support for a custom logit processor base class that can be finalized post-generation. The implementations will come in a subsequent PR. 