### PR TITLE
Used PREFIX from RedisStorage instead of using it from the instance

### DIFF
--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -285,7 +285,7 @@ class GlobalRateLimiter:
             while cursor:
                 cursor, keys = await client.scan(
                     int(cursor),
-                    match=f"{storage.PREFIX}*",
+                    match=f"{storage.bridge.PREFIX}*",
                     count=cursor_scan_count,
                 )
                 matching_keys.extend(list(keys))

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -284,7 +284,7 @@ class GlobalRateLimiter:
             while cursor:
                 cursor, keys = await client.scan(
                     int(cursor),
-                    match=f"{self.storage.PREFIX}*",
+                    match=f"{RedisStorage.PREFIX}*",
                     count=cursor_scan_count,
                 )
                 matching_keys.extend(list(keys))

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -271,7 +271,8 @@ class GlobalRateLimiter:
         if not (host and port):
             raise ValueError(f"Invalid Redis URL: {redis_url}.")
 
-        if not isinstance(self.storage, RedisStorage):
+        storage = self.storage
+        if not isinstance(storage, RedisStorage):
             raise NotImplementedError(
                 "get_rate_limit_keys only works with RedisStorage."
             )
@@ -284,7 +285,7 @@ class GlobalRateLimiter:
             while cursor:
                 cursor, keys = await client.scan(
                     int(cursor),
-                    match=f"{RedisStorage.PREFIX}*",
+                    match=f"{storage.PREFIX}*",
                     count=cursor_scan_count,
                 )
                 matching_keys.extend(list(keys))

--- a/uv.lock
+++ b/uv.lock
@@ -1605,16 +1605,16 @@ wheels = [
 
 [[package]]
 name = "limits"
-version = "4.0.1"
+version = "4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deprecated" },
     { name = "packaging" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/03/91618859fc967fd727a3ecce5f7d9b0322152fa81c4a1bdd1f8afcfc5185/limits-4.0.1.tar.gz", hash = "sha256:a54f5c058dfc965319ae3ee78faf222294659e371b46d22cd7456761f7e46d5a", size = 70787 }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/54/f73e4810332f500b46b3fbf01d3258e0cbf1508d1be8d2438a1e174208c3/limits-4.2.tar.gz", hash = "sha256:d602ceae5d6b71063d5f9338904e32d569efaa84a7dd0399cde7ca6ff1a8fc9b", size = 85710 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/7a/6d84edd5a6bf666cdb14f8aaa3363c341271e0fa19e645e575ac0afd26d1/limits-4.0.1-py3-none-any.whl", hash = "sha256:67667e669f570cf7be4e2c2bc52f763b3f93bdf66ea945584360bc1a3f251901", size = 45753 },
+    { url = "https://files.pythonhosted.org/packages/94/85/8bea229501a81c9faf5c13aff158edcb523be011a1a4b9cb8a6d49605f54/limits-4.2-py3-none-any.whl", hash = "sha256:e6b66078dfb11b971fc3a2a794c598697bce3d9cf7bff242fa0b413875b86dea", size = 60504 },
 ]
 
 [[package]]


### PR DESCRIPTION
`limits` changed how to get the `PREFIX` from `RedisStorage` on version 4.2.
We're getting it directly from the class now