### PR TITLE
Revert "Rollout Manager & Chunking Improvements"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,5 +297,3 @@ cython_debug/
 
 # Version files made by setuptools_scm
 **/version.py
-
-.vscode/

--- a/src/ldp/alg/rollout.py
+++ b/src/ldp/alg/rollout.py
@@ -2,13 +2,11 @@ import asyncio
 import itertools
 import logging
 import uuid
-from collections import Counter
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager, nullcontext
 from typing import Any, TypeVar, overload
 
 from aviary.core import Environment, Message
-from tqdm.asyncio import tqdm
 
 from ldp.agent import Agent
 from ldp.data_structures import Trajectory, Transition
@@ -26,7 +24,6 @@ class CaughtError(Exception):
     """Base class for reraised exceptions when catching is enabled."""
 
     def __init__(self, original_exc: Exception):
-        super().__init__(str(original_exc))
         self.original_exc = original_exc
 
     exc_type = "undefined"
@@ -42,12 +39,12 @@ class EnvError(CaughtError):
 
 @contextmanager
 def reraise_exc_as(reraise: type[CaughtError], enabled: bool) -> Iterator[None]:
-    """Context manager that reraises exceptions as a custom CaughtError type if enabled."""
     try:
         yield
     except Exception as e:
         if enabled:
-            logger.debug(f"Reraising {reraise.exc_type} exception.")
+            error_details = format_error_details(e)
+            logger.exception(f"Caught {reraise.exc_type} exception:\n{error_details}")
             raise reraise(e) from None
         raise
 
@@ -109,9 +106,6 @@ class RolloutManager:
             environments: A list of environments to run rollouts on.
             max_steps: Max steps per rollout. Defaults to None, in which case the rollouts are run
                 until environment returns done.
-            summarize_exceptions: Whether to collect exceptions and show a summary at the end.
-                Defaults to True. If False, exceptions will be logged immediately as they occur
-                during rollout.
         """
 
     async def sample_trajectories(self, **kwargs):
@@ -124,7 +118,6 @@ class RolloutManager:
                 kwargs["environment_factory"],
                 kwargs.get("batch_size", 1),
                 kwargs.get("max_steps"),
-                summarize_exceptions=kwargs.get("summarize_exceptions", False),
             )
 
         if "environments" in kwargs:
@@ -132,12 +125,7 @@ class RolloutManager:
                 "Cannot use environments with environment_factory"
             )
             return await self._sample_trajectories_from_envs(
-                kwargs["environments"],
-                kwargs.get("max_steps"),
-                summarize_exceptions=kwargs.get(
-                    "summarize_exceptions",
-                    False,
-                ),
+                kwargs["environments"], kwargs.get("max_steps")
             )
 
         raise TypeError(
@@ -150,18 +138,13 @@ class RolloutManager:
         environment_factory: Callable[[], Environment],
         batch_size: int = 1,
         max_steps: int | None = None,
-        *,
-        summarize_exceptions: bool = False,
     ) -> list[tuple[Trajectory, Environment]]:
         self.traj_buffer.clear()
-        exception_counter: Counter = Counter()
 
         async def rollout_with_args(idx: int, **rollout_kwargs):
             return idx, await self._rollout(**rollout_kwargs), rollout_kwargs
 
         accumulated_steps = [0] * batch_size
-        total_trajectories = 0  # Counter for completed trajectories
-
         # submit initial batch of tasks
         tasks = [
             asyncio.create_task(
@@ -170,67 +153,37 @@ class RolloutManager:
                     traj_id=uuid.uuid4().hex,
                     env=environment_factory(),
                     max_steps=max_steps,
-                    summarize_exceptions=summarize_exceptions,
                 )
             )
             for idx in range(batch_size)
         ]
 
         results = []
-        with tqdm(
-            desc="Rollouts",
-            unit="rollout",
-            ncols=0,
-            disable=not summarize_exceptions,
-        ) as pbar:
-            while tasks:
-                done, pending = await asyncio.wait(
-                    tasks, return_when=asyncio.FIRST_COMPLETED
-                )
-                new_tasks = []
-                for task in done:
-                    idx, traj, kwargs = await task
-                    results.append((traj, kwargs["env"]))
-                    total_trajectories += 1
-                    pbar.update(1)
-
-                    steps_in_traj = len(traj.steps)
-                    accumulated_steps[idx] += steps_in_traj
-
-                    # Check for exceptions in this trajectory
-                    if traj.steps and traj.steps[-1].metadata.get("exception"):
-                        exc_str: str = str(traj.steps[-1].metadata["exception"])[
-                            :500
-                        ].replace('"', "'")
-                        exception_counter[exc_str] += 1
-                        num_exceptions = sum(exception_counter.values())
-                        pbar.set_postfix({"num_exceptions": num_exceptions})
-
-                    if (
-                        max_steps is not None
-                        and (remaining_steps := max_steps - accumulated_steps[idx]) > 0
-                    ):
-                        # submit another task if we haven't reached max_steps
-                        new_task = asyncio.create_task(
-                            rollout_with_args(
-                                idx,
-                                traj_id=uuid.uuid4().hex,
-                                env=environment_factory(),
-                                max_steps=remaining_steps,
-                                summarize_exceptions=summarize_exceptions,
-                            )
-                        )
-                        new_tasks.append(new_task)
-
-                tasks = list(pending) + new_tasks
-
-        # Final summary of exceptions (if any)
-        if exception_counter and summarize_exceptions:
-            summary = ["Caught exceptions:", "Count  Exception"]
-            summary.extend(
-                f"{count:<6d} {exc:<50s}" for exc, count in exception_counter.items()
+        while tasks:
+            done, pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
             )
-            logger.info("\n".join(summary))
+            new_tasks = []
+            for task in done:
+                idx, traj, kwargs = await task
+                results.append((traj, kwargs["env"]))
+                accumulated_steps[idx] += len(traj.steps)
+                if (
+                    max_steps is not None
+                    and (remaining_steps := max_steps - accumulated_steps[idx]) > 0
+                ):
+                    # submit another task if we haven't reached max_steps
+                    new_task = asyncio.create_task(
+                        rollout_with_args(
+                            idx,
+                            traj_id=uuid.uuid4().hex,
+                            env=environment_factory(),
+                            max_steps=remaining_steps,
+                        )
+                    )
+                    new_tasks.append(new_task)
+
+            tasks = list(pending) + new_tasks
 
         return results
 
@@ -238,57 +191,16 @@ class RolloutManager:
         self,
         environments: Sequence[Environment],
         max_steps: int | None = None,
-        *,
-        summarize_exceptions: bool = False,
     ) -> list[Trajectory]:
         self.traj_buffer.clear()
-        exception_counter: Counter = Counter()
 
-        traj_ids = [uuid.uuid4().hex for _ in environments]
-
-        # Create all tasks first
-        tasks = [
-            asyncio.create_task(
-                self._rollout(
-                    traj_id,
-                    env,
-                    max_steps=max_steps,
-                    summarize_exceptions=summarize_exceptions,
-                )
+        traj_ids = [uuid.uuid4().hex for _ in range(len(environments))]
+        await asyncio.gather(
+            *(
+                self._rollout(*args, max_steps=max_steps)
+                for args in zip(traj_ids, environments, strict=True)
             )
-            for traj_id, env in zip(traj_ids, environments, strict=True)
-        ]
-
-        with tqdm(
-            total=len(tasks),
-            desc="Rollouts",
-            unit="rollout",
-            ncols=0,
-            disable=not summarize_exceptions,
-        ) as pbar:
-            for task in asyncio.as_completed(tasks):
-                trajectory = await task
-                pbar.update(1)
-                # Check if this trajectory ended with an exception
-                if trajectory.steps:
-                    last_step = trajectory.steps[-1]
-                    if last_step.metadata.get("exception"):
-                        # We'll keep it short but still have something to categorize
-                        exc_str: str = str(last_step.metadata["exception"])[
-                            :500
-                        ].replace('"', "'")
-                        exception_counter[exc_str] += 1
-                        num_exceptions = sum(exception_counter.values())
-                        pbar.set_postfix({"num_exceptions": num_exceptions})
-
-        # Final summary of exceptions (if any)
-        if exception_counter and summarize_exceptions:
-            summary = ["Caught exceptions:", "Count  Exception"]
-            summary.extend(
-                f"{count:<6d} {exc:<50s}" for exc, count in exception_counter.items()
-            )
-            logger.info("\n".join(summary))
-
+        )
         return [self.traj_buffer[traj_id] for traj_id in traj_ids]
 
     async def _rollout(
@@ -296,8 +208,6 @@ class RolloutManager:
         traj_id: str,
         env: Environment,
         max_steps: int | None,
-        *,
-        summarize_exceptions: bool = False,
     ) -> Trajectory:
         trajectory = Trajectory(traj_id=traj_id)
 
@@ -350,10 +260,6 @@ class RolloutManager:
         except CaughtError as e:
             # NOTE: This trajectory should not be used for regular training.
             # We save the last transition here for debugging, etc.
-            if not summarize_exceptions:
-                error_details = format_error_details(e.original_exc)
-                logger.exception(f"Exception in rollout {traj_id}:\n{error_details}")
-
             await store_step(
                 Transition(
                     timestep=len(trajectory.steps),

--- a/src/ldp/nn/agent/simple_local_agent.py
+++ b/src/ldp/nn/agent/simple_local_agent.py
@@ -1,10 +1,8 @@
-import logging
 from typing import cast
 
 import torch
 import torch.distributed as dist
 from aviary.core import Message, Tool, ToolRequestMessage
-from litellm.utils import token_counter
 from pydantic import Field, field_validator
 
 from ldp.agent import Agent, SimpleAgentState
@@ -18,8 +16,6 @@ from ldp.nn.handlers.transformer_handler import (
     logits_to_logprobs,
 )
 from ldp.nn.lm_config import LMConfig as _LMConfig
-
-logger = logging.getLogger(__name__)
 
 
 class AgentLMConfig(_LMConfig):
@@ -45,13 +41,6 @@ class AgentLMConfig(_LMConfig):
             "are better defaults than HF's."
         ),
         validate_default=True,
-    )
-    max_token_count: int | None = Field(
-        default=None,
-        description=(
-            "If set, raise an error if the total tokens in the message history "
-            "and tool description exceed this value."
-        ),
     )
 
     @field_validator("llm_call_kwargs")
@@ -102,8 +91,6 @@ class SimpleLocalLLMAgent(Agent[SimpleAgentState]):
             else next_state.messages
         )
 
-        self._validate_token_count(messages, next_state.tools)
-
         # Execute the LLM operation call
         result = cast(
             "OpResult[Message | ToolRequestMessage]",
@@ -126,26 +113,6 @@ class SimpleLocalLLMAgent(Agent[SimpleAgentState]):
         # Update state messages with result and return the new state
         next_state.messages = [*next_state.messages, result.value]
         return cast("OpResult[ToolRequestMessage]", result), next_state, 0.0
-
-    def _validate_token_count(self, messages: list[Message], tools: list[Tool]):
-        """Asserts token count for the trajectory is within the limit."""
-        if self.llm_model.max_token_count is None:
-            return
-        messages_for_tokenizer = self._llm_call_op.prep_messages_for_tokenizer(messages)
-        tools_for_tokenizer = self._llm_call_op.prep_tools_for_tokenizer(tools)
-
-        total_tokens = token_counter(
-            model=self.llm_model.model,
-            messages=messages_for_tokenizer,
-            tools=tools_for_tokenizer,  # type: ignore[arg-type]
-        )
-        if total_tokens > self.llm_model.max_token_count:
-            logger.error(
-                f"Token limit exceeded: {total_tokens} > {self.llm_model.max_token_count}"
-            )
-            raise ValueError(
-                f"Token limit exceeded: {total_tokens} > {self.llm_model.max_token_count}"
-            )
 
     # TODO: maybe remove these recomputation methods. I added them to debug some things. But idk,
     # maybe they'll come in handy later.

--- a/src/ldp/nn/handlers/chunking.py
+++ b/src/ldp/nn/handlers/chunking.py
@@ -9,8 +9,9 @@ TOutputType = TypeVar("TOutputType", torch.Tensor, GenerateDecoderOnlyOutput)
 class TensorChunker:
     """Splits tensors into chunks and adds dummy chunks as needed for parallel processing frameworks like FSDP."""
 
-    def __init__(self, num_chunks: int):
+    def __init__(self, num_chunks: int, dummy_value: int = 0):
         self.num_chunks = num_chunks
+        self.dummy_value = dummy_value
 
     def chunkify(self, *args, **kwargs) -> tuple[list[tuple], list[dict], list[bool]]:
         """Splits the args into self.num_chunks chunks, adding dummy chunks as needed.
@@ -158,10 +159,8 @@ class TensorChunker:
             for i in range(self.num_chunks):
                 if i >= len(chunks):
                     # Chunk 0 will always exist, and we need only a batch of one ([:1])
-                    # to activate the model.
-                    # We use the first element of the existing chunks as real data to avoid
-                    # errors in the model that may expect a specific token structure.
-                    chunks.append(chunks[0][:1])
+                    # to activate the model
+                    chunks.append(torch.full_like(chunks[0][:1], self.dummy_value))
                     dummy_chunk_flags.append(True)
                 else:
                     dummy_chunk_flags.append(False)

--- a/src/ldp/nn/handlers/transformer_handler.py
+++ b/src/ldp/nn/handlers/transformer_handler.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-import atexit
 import logging
 import os
 import socket
@@ -11,15 +9,14 @@ from collections.abc import Awaitable, Callable
 from enum import StrEnum, auto
 from functools import cache, partial, wraps
 from pathlib import Path
-from typing import Any, Concatenate, ParamSpec, Self, TypeVar, assert_never
+from typing import Any, Concatenate, ParamSpec, Self, TypeVar, assert_never, cast
 
 import accelerate
 import torch
 import torch.distributed as dist
 import tree
 from dask import config
-from dask.distributed import Actor, ActorFuture, Client
-from distributed.utils import sync
+from dask.distributed import Client
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from torch import nn
 from torch.cuda import nccl
@@ -48,7 +45,6 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import overload  # noqa: UP035
 
-logger = logging.getLogger(__name__)
 
 config.set({
     # We have no use for rebooting workers in aviary for now, and rebooting workers
@@ -59,8 +55,10 @@ config.set({
     # Gives us more time to debug a downed worker. TODO: see if there are negative consequences
     # of having this always enabled
     "distributed.comm.timeouts.connect": "300s",
-    "distributed.comm.timeouts.tcp": "1200s",
+    "distributed.comm.timeouts.tcp": "300s",
 })
+
+logger = logging.getLogger(__name__)
 
 TReturn = TypeVar("TReturn")
 TParams = ParamSpec("TParams")
@@ -419,29 +417,22 @@ class ParallelTransformerHandler(TransformerHandler):
         args = tree.map_structure(to_device, args)
         kwargs = tree.map_structure(to_device, kwargs)
 
-        try:
-            with torch.autocast(
-                device_type=self.module.device.type, dtype=self.module.dtype
-            ):
-                res = (
-                    getattr(self, func)(*args, **kwargs)
-                    if isinstance(func, str)
-                    else func(self, *args, **kwargs)
-                )
+        with torch.autocast(
+            device_type=self.module.device.type, dtype=self.module.dtype
+        ):
+            res = (
+                getattr(self, func)(*args, **kwargs)
+                if isinstance(func, str)
+                else func(self, *args, **kwargs)
+            )
 
-            # Needed to prevent GPU memory leak to the main process scheduling the workers
-            if isinstance(res, GenerateDecoderOnlyOutput):
-                res.past_key_values = None
-                res["past_key_values"] = None
+        # Needed to prevent GPU memory leak to the main process scheduling the workers
+        if isinstance(res, GenerateDecoderOnlyOutput):
+            res.past_key_values = None
+            res["past_key_values"] = None
 
-            to_cpu = partial(_move_tensor, device=torch.device("cpu"))
-            return tree.map_structure(to_cpu, res)
-        except Exception as e:
-            # Re-raise the exception with traceback preserved. For some exceptions, Dask
-            # modifies or loses the original traceback when crossing process boundaries.
-            # RuntimeError preserves the traceback when using with_traceback() of original
-            # exception.
-            raise RuntimeError(str(e)).with_traceback(e.__traceback__)  # noqa: B904
+        to_cpu = partial(_move_tensor, device=torch.device("cpu"))
+        return tree.map_structure(to_cpu, res)
 
     def __del__(self) -> None:
         dist.destroy_process_group()
@@ -472,8 +463,6 @@ class ParallelAsyncTransformer(AsyncTransformerInterface):
 
         self._initialized = True
 
-        atexit.register(self.teardown)
-
         # don't call AsyncTorchModule.__init__ because we don't need to set up module[_call_fn]
         AsyncBufferedWorker.__init__(
             self,
@@ -495,10 +484,6 @@ class ParallelAsyncTransformer(AsyncTransformerInterface):
         # lazy import since dask-cuda only works on Linux machines
         from dask_cuda import LocalCUDACluster
 
-        # This uses NVIDIA's NVML layer instead of native CUDA, which is more robust in GPU detection
-        # post initialization. This prevents issues with forked processes wrongly detecting the
-        # default GPU as cuda:0
-        os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = "1"
         self.cluster = LocalCUDACluster(
             n_workers=parallel_mode_config.num_workers,
             threads_per_worker=parallel_mode_config.num_cpus_per_worker,
@@ -583,7 +568,7 @@ class ParallelAsyncTransformer(AsyncTransformerInterface):
             futures.append(future_op)
             worker_ids.append(worker_id)
 
-        self.actors: list[Actor] = self._client_gather(futures)
+        self.handlers = self.client.gather(futures)
         self.worker_ids = worker_ids
 
     async def __call__(
@@ -634,24 +619,28 @@ class ParallelAsyncTransformer(AsyncTransformerInterface):
         """
         if split_data:
             chunker = TensorChunker(
-                num_chunks=len(self.actors),
+                num_chunks=len(self.handlers),
             )
             split_args, split_kwargs, dummy_flags = chunker.chunkify(*args, **kwargs)
         else:
-            split_args = [args] * len(self.actors)
-            split_kwargs = [kwargs] * len(self.actors)
+            split_args = [args] * len(self.handlers)
+            split_kwargs = [kwargs] * len(self.handlers)
 
         futures = [
-            handler._exec_func(
+            self.client.submit(
+                handler._exec_func,
                 func,
                 *args_i,
+                workers=[worker_id],
+                actor=True,
                 **kwargs_i,
             )
             for handler, worker_id, args_i, kwargs_i in zip(
-                self.actors, self.worker_ids, split_args, split_kwargs, strict=True
+                self.handlers, self.worker_ids, split_args, split_kwargs, strict=True
             )
         ]
-        results: list[TReturn] = self._client_gather(futures)
+        results = self.client.gather(futures)
+        results = cast("list[TReturn]", [res.result().result() for res in results])
 
         if split_data:
             return chunker.dechunkify(results, dummy_flags)
@@ -762,77 +751,12 @@ class ParallelAsyncTransformer(AsyncTransformerInterface):
 
     def teardown(self) -> None:
         if self._initialized:
-            self.client.shutdown()
+            self.client.close()
             self.cluster.close()
-            del self.client
-            del self.cluster
             self._initialized = False
 
     def __del__(self) -> None:
         self.teardown()
-
-    @staticmethod
-    def _wrap_dask_future(dask_future: ActorFuture):
-        """Converts a Dask ActorFuture into an awaitable asyncio.Future."""
-        loop = asyncio.get_running_loop()
-        return asyncio.ensure_future(loop.run_in_executor(None, dask_future.result))
-
-    @staticmethod
-    def _raise_exceptions(done, pending, wrapped_futures):
-        exceptions = []
-        for future in done:
-            exc = future.exception()
-            if exc:
-                exceptions.append(exc)
-        if exceptions:
-            if len(exceptions) == 1:
-                raise exceptions[0]
-            raise ExceptionGroup("Multiple actor exceptions", exceptions)
-
-        if pending:
-            pending_indices = sorted([wrapped_futures.index(p) for p in pending])
-            raise TimeoutError(
-                f"Tasks didn't complete within timeout. {len(pending)} out of {len(wrapped_futures)} "
-                f"still pending. Pending task indices: {pending_indices}"
-            )
-
-    async def _client_gather_async(self, futures):
-        """Gather results from futures, propagating exceptions as they arrive.
-
-        Unlike client.gather() which waits for all futures to complete before raising
-        any exceptions, this method processes futures as they complete and raises
-        exceptions immediately. This is crucial when using FSDP where workers may
-        be stuck waiting for each other when one worker crashes, causing long hangs.
-
-        Note: Dask Actors currently have an issue where they're not working properly with
-        dask.gather() and can cause blocking issues or hide worker errors. This implementation
-        works around those limitations.
-        """
-        try:
-            wrapped_futures = [self._wrap_dask_future(f) for f in futures]
-
-            # Use asyncio.wait with FIRST_EXCEPTION instead of gather
-            done, pending = await asyncio.wait(
-                wrapped_futures, timeout=1200, return_when=asyncio.FIRST_EXCEPTION
-            )
-
-            self._raise_exceptions(done, pending, wrapped_futures)
-
-            return await asyncio.gather(*wrapped_futures)
-        except Exception:
-            logger.exception("Error in dask workers: %s")
-            for future in wrapped_futures:
-                future.cancel()
-            self.teardown()
-            # sys.exit(1) would wait for dask to finish, which can cause hanging
-            # when workers are in a deadlock. Use os._exit to force immediate termination
-            # TODO: this is more of a hack, we should propagate special exception that is
-            # not caught by the rollout manager.
-            os._exit(1)
-
-    def _client_gather(self, futures: list[ActorFuture]) -> list[Any]:
-        # Use distributed.utils.sync to run the async function in the current thread
-        return sync(self.client.loop, self._client_gather_async, futures)  # type: ignore[arg-type]
 
 
 # Helpers

--- a/tests/test_nn_models.py
+++ b/tests/test_nn_models.py
@@ -27,10 +27,11 @@ class TestTensorChunker:
     def test_chunkify_add_dummy_chunks(self):
         batch_size = 3
         num_chunks = 5
+        dummy_value = 0
 
         sample_tensor = torch.arange(1, batch_size * 10 + 1).reshape(batch_size, 10)
 
-        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks)
+        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks, dummy_value=dummy_value)
         split_args, split_kwargs, dummy_chunk_flags = chunker.chunkify(sample_tensor)
 
         assert len(split_args) == num_chunks
@@ -39,16 +40,21 @@ class TestTensorChunker:
         assert torch.equal(split_args[0][0], sample_tensor[:1])
         assert torch.equal(split_args[1][0], sample_tensor[1:2])
         assert torch.equal(split_args[2][0], sample_tensor[2:3])
-        assert torch.equal(split_args[3][0], sample_tensor[:1])
-        assert torch.equal(split_args[4][0], sample_tensor[:1])
+        assert torch.equal(
+            split_args[3][0], torch.full_like(sample_tensor[:1], dummy_value)
+        )
+        assert torch.equal(
+            split_args[4][0], torch.full_like(sample_tensor[:1], dummy_value)
+        )
 
     def test_chunkify_no_dummy_chunks(self):
         batch_size = 9
         num_chunks = 5
+        dummy_value = 0
 
         sample_tensor = torch.arange(1, batch_size * 10 + 1).reshape(batch_size, 10)
 
-        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks)
+        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks, dummy_value=dummy_value)
         split_args, split_kwargs, dummy_chunk_flags = chunker.chunkify(sample_tensor)
 
         assert len(split_args) == num_chunks
@@ -63,6 +69,7 @@ class TestTensorChunker:
     def test_chunkify_with_args_and_kwargs(self):
         batch_size = 2
         num_chunks = 3
+        dummy_value = 0
 
         sample_tensor = torch.arange(1, batch_size * 10 + 1).reshape(batch_size, 10)
         sample_tensor_kwarg = torch.arange(1, batch_size * 5 + 1).reshape(batch_size, 5)
@@ -71,7 +78,7 @@ class TestTensorChunker:
             "key2": "Not split",
         }
 
-        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks)
+        chunker = ldp.nn.TensorChunker(num_chunks=num_chunks, dummy_value=dummy_value)
         split_args, split_kwargs, dummy_chunk_flags = chunker.chunkify(
             sample_tensor, **sample_kwargs
         )
@@ -81,10 +88,15 @@ class TestTensorChunker:
         assert dummy_chunk_flags == [False, False, True]
         assert torch.equal(split_args[0][0], sample_tensor[:1])
         assert torch.equal(split_args[1][0], sample_tensor[1:2])
-        assert torch.equal(split_args[2][0], sample_tensor[:1])
+        assert torch.equal(
+            split_args[2][0], torch.full_like(sample_tensor[:1], dummy_value)
+        )
         assert torch.equal(split_kwargs[0]["key1"], sample_tensor_kwarg[:1])
         assert torch.equal(split_kwargs[1]["key1"], sample_tensor_kwarg[1:2])
-        assert torch.equal(split_kwargs[2]["key1"], sample_tensor_kwarg[:1])
+        assert torch.equal(
+            split_kwargs[2]["key1"],
+            torch.full_like(sample_tensor_kwarg[:1], dummy_value),
+        )
         assert all(split_kwargs[i]["key2"] == "Not split" for i in range(num_chunks))
 
     def test_dechunkify(self):


### PR DESCRIPTION
Reverts #231 

We can no longer see the original stack trace of a caught exception - this makes debugging difficult. Reverting until this is understood.
```
ldp.graph.common_ops.LLMCallOp._call_single_and_maybe_validate() got multiple values for keyword argument 'model'
Traceback (most recent call last):
  File "/Users/ryan-rhysgriffiths/miniconda3/envs/aviary4/lib/python3.12/site-packages/ldp/alg/rollout.py", line 333, in _rollout
    step = await self._take_step(timestep, traj_id, env, agent_state, obs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryan-rhysgriffiths/miniconda3/envs/aviary4/lib/python3.12/site-packages/ldp/alg/rollout.py", line 387, in _take_step
    with reraise_exc_as(AgentError, enabled=self.catch_agent_failures):
  File "/Users/ryan-rhysgriffiths/miniconda3/envs/aviary4/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/ryan-rhysgriffiths/miniconda3/envs/aviary4/lib/python3.12/site-packages/ldp/alg/rollout.py", line 51, in reraise_exc_as
    raise reraise(e) from None
```