### PR TITLE
Allow agent fallback configuration

### DIFF
--- a/.secrets.allowlist
+++ b/.secrets.allowlist
@@ -1,2 +1,3 @@
 authorization
 x-api-key
+abc123

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -11,6 +11,7 @@ __all__ = [
 
 import asyncio
 import contextlib
+import copy
 import functools
 import json
 import logging
@@ -231,7 +232,7 @@ class LLMModel(ABC, BaseModel):
         output_type: type[BaseModel] | TypeAdapter | JSONSchema | None = None,
         tools: list[Tool] | None = None,
         tool_choice: Tool | str | None = TOOL_CHOICE_REQUIRED,
-        **chat_kwargs,
+        **kwargs,
     ) -> list[LLMResult]:
         """Call the LLM model with the given messages and configuration.
 
@@ -247,6 +248,11 @@ class LLMModel(ABC, BaseModel):
         Raises:
             ValueError: If the LLM type is unknown.
         """
+        chat_kwargs = copy.deepcopy(kwargs)
+        # if using the config for an LLMModel,
+        # there may be a nested 'config' key
+        # that can't be used by chat
+        chat_kwargs.pop("config")
         n = chat_kwargs.get("n") or self.config.get("n", 1)
         if n < 1:
             raise ValueError("Number of completions (n) must be >= 1.")
@@ -527,13 +533,20 @@ class LiteLLMModel(LLMModel):
 
     @model_validator(mode="before")
     @classmethod
-    def maybe_set_config_attribute(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def maybe_set_config_attribute(cls, input_data: dict[str, Any]) -> dict[str, Any]:
         """
         Set the config attribute if it is not provided.
 
         If name is not provided, uses the default name.
         If a user only gives a name, make a sensible config dict for them.
         """
+        data = copy.deepcopy(input_data)
+
+        # unnest the config key if it's nested
+        if "config" in data and "config" in data["config"]:
+            data["config"].update(data["config"]["config"])
+            data["config"].pop("config")
+
         if "config" not in data:
             data["config"] = {}
         if "name" not in data:

--- a/src/ldp/graph/common_ops.py
+++ b/src/ldp/graph/common_ops.py
@@ -281,7 +281,10 @@ class LLMCallOp(Op[Message]):
             messages=msgs,
             tools=tools,
             tool_choice=tool_choice,
-            **config,
+            # Since config is shared between our LLMModel and our `call` options
+            # we need to ensure we remove keys which work with LLMModel
+            # but not `call`.
+            **{k: v for k, v in config.items() if k != "router_kwargs"},
         )
         if result.messages is None:
             raise ValueError("No messages returned")

--- a/tests/cassettes/test_fallbacks_working[False].yaml
+++ b/tests/cassettes/test_fallbacks_working[False].yaml
@@ -1,0 +1,85 @@
+interactions:
+  - request:
+      body:
+        '{"messages":[{"role":"user","content":"Hello!"}],"model":"gpt-4o-mini","n":1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"talk","description":"Say
+        something to me.","parameters":{"type":"object","properties":{"message":{"description":"what
+        you want to say","title":"Message","type":"string"}},"required":["message"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "348"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.65.2
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.65.2
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          "{\n    \"error\": {\n        \"message\": \"Incorrect API key provided:
+          abc123. You can find your API key at https://platform.openai.com/account/api-keys.\",\n
+          \       \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\":
+          \"invalid_api_key\"\n    }\n}\n"
+      headers:
+        CF-RAY:
+          - 93106ee58a25e9e1-LAX
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "256"
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 16 Apr 2025 03:00:34 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=fno7x_jxANnm27vgnNYNxHE09oaBaF..5rUNTsRQ1WI-1744772434-1.0.1.1-rsmcL1TWF3LBc0flL7Kmdpy1VXvWhNk7QMMykdrKSZJ.bnFPZCzILfUcIZc6xZDGKuaUQwHRadfN6xtPvj4gkVo_4mM6lTZZPyrOWWDdmCg;
+            path=/; expires=Wed, 16-Apr-25 03:30:34 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=S6PXUFvHj99UvUnTDkwFAy45z3FyWDJESdzHk5S0Hy8-1744772434881-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        vary:
+          - Origin
+        x-request-id:
+          - req_aedfefa7d8f530b37b53effeaa97d3a0
+      status:
+        code: 401
+        message: Unauthorized
+version: 1

--- a/tests/cassettes/test_fallbacks_working[True].yaml
+++ b/tests/cassettes/test_fallbacks_working[True].yaml
@@ -1,0 +1,390 @@
+interactions:
+  - request:
+      body:
+        '{"messages":[{"role":"user","content":"Hello!"}],"model":"gpt-4o-mini","n":1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"talk","description":"Say
+        something to me.","parameters":{"type":"object","properties":{"message":{"description":"what
+        you want to say","title":"Message","type":"string"}},"required":["message"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "348"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.65.2
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.65.2
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          "{\n    \"error\": {\n        \"message\": \"Incorrect API key provided:
+          abc123. You can find your API key at https://platform.openai.com/account/api-keys.\",\n
+          \       \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\":
+          \"invalid_api_key\"\n    }\n}\n"
+      headers:
+        CF-RAY:
+          - 93106ed498197baf-LAX
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "256"
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 16 Apr 2025 03:00:32 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=0mG2.1O37IAVGq_oAXM7oMqT962W.LNgsCsJXOp4o84-1744772432-1.0.1.1-YjCnI4YfXy5vhjydJa5x_cDSuLaGMTSdQ02JU3wWWv4M9LEiKhOCb1vXwFnWZRc4Kg4eBsYCfQG62jHjsXmGy08nWrbq03BdO5QbuXxVhSw;
+            path=/; expires=Wed, 16-Apr-25 03:30:32 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=5rsZ0hVeaghSzN8vpHsamJuxGZZwHWNrpUudAjgiyA0-1744772432156-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        vary:
+          - Origin
+        x-request-id:
+          - req_292bebceac2c846720c61dc771dfa265
+      status:
+        code: 401
+        message: Unauthorized
+  - request:
+      body:
+        '{"messages":[{"role":"user","content":"Hello!"}],"model":"gpt-4o","n":1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"talk","description":"Say
+        something to me.","parameters":{"type":"object","properties":{"message":{"description":"what
+        you want to say","title":"Message","type":"string"}},"required":["message"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "343"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.65.2
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.65.2
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA4xTwW7bMAy9+ys0npMhcdwm9WVYD0sDbNiK7jB0KQxVph21siRI9Fo3yL8PthPb
+          STNgPhgCnx75+EhtA8ZAphAzEBtOorBqfP1Nr4oqvLq/rRS+3a7Ifynvl+mTenWTNxjVDPP4hIIO
+          rI/CFFYhSaNbWDjkhHXW6TyK5vMwmoUNUJgUVU3LLY0jMw4nYTSeLMaTyz1xY6RADzH7HTDG2Lb5
+          1xJ1iq8Qs8noECnQe54jxN0lxsAZVUeAey89cU0w6kFhNKGuVetSqQFAxqhEcKX6wu23HZx7n7hS
+          ye33+Y+7/OvLcvkL70L3+eLntZ0uZmJQr01d2UZQVmrR+TPAu3h8Uowx0LxouMTV8wmPMeAuLwvU
+          VGuG7frgxxriNdxIRht0+IHdmBcmuGYr1lrCKlMyMimvPq1hB0dJd8G588PAKIdZ6bl67yDX2hCv
+          G2ksfNgju25ayuTWmUd/QoVMauk3iUPuGxOGswgOQhoJUB6NG6wzhaWEzDM2RS9mbVLol7EHw2gP
+          kiGu+vh8PjqTLUmRuGy2oVtAwcUG057ZLyIvU2kGQDDo/L2Yc7nb7qXO/yd9DwiBljBNrMNUiuOG
+          +2sO66f6r2udx41g8Oj+SIEJSXT1NFLMeKnaVwS+8oRFkkmdo7NONk8JMptchdk0wsXlYgbBLvgL
+          AAD//wMAPIi+ZlMEAAA=
+      headers:
+        CF-RAY:
+          - 93106ed5eb717ba1-LAX
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 16 Apr 2025 03:00:33 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=swFj_E1tv_pFytUG_KkWJ3EkMiZ64TQREuyb4K3dfXw-1744772433-1.0.1.1-g_Ux0.tIe3I1CP.z1sGs9pFaKJ4t69kFyQLOLnB5pETfSjtOF2DE7hQljHKQxpOLMvKIlHzfmzU1aD1Zwmqr5XSPeXMyITO2MReQ_W2IdQc;
+            path=/; expires=Wed, 16-Apr-25 03:30:33 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=lANEmu3WQPqxaRgDtxNkeu.LB2RLF6zMknnXPc2FOjY-1744772433129-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "428"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29999995"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_ba4a6ac663970c2eeb41590741827291
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"messages":[{"role":"user","content":"Hello!"},{"role":"assistant","content":null,"function_call":null,"tool_calls":[{"id":"call_QO7PSgLwGGXeS2rA5TBp183c","type":"function","function":{"arguments":"{\"message\":
+        \"Hi there! How can I assist you today?\"}","name":"talk"}}]},{"role":"tool","content":"Hi
+        there! How can I assist you today?","name":"talk","tool_call_id":"call_QO7PSgLwGGXeS2rA5TBp183c"}],"model":"gpt-4o-mini","n":1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"talk","description":"Say
+        something to me.","parameters":{"type":"object","properties":{"message":{"description":"what
+        you want to say","title":"Message","type":"string"}},"required":["message"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "702"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.65.2
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.65.2
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string:
+          "{\n    \"error\": {\n        \"message\": \"Incorrect API key provided:
+          abc123. You can find your API key at https://platform.openai.com/account/api-keys.\",\n
+          \       \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\":
+          \"invalid_api_key\"\n    }\n}\n"
+      headers:
+        CF-RAY:
+          - 93106edd7e6d2ae8-LAX
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "256"
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 16 Apr 2025 03:00:33 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=b1StBFVQ5Q.Cvx_qg0emaQsxAelo4og2XS1doFxthVg-1744772433-1.0.1.1-tpPpNrPFLRsYGWuQ6_EF5ZJ.K6jjNI35pu6g2LDQ9OWy2v5Wk8z7UF6AqHMlHJ9omVjOu8JCPPOgo5Ta.8rA06GXw0ajXm6bFX1pjLbhqjU;
+            path=/; expires=Wed, 16-Apr-25 03:30:33 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=q1HpNzOWPSRynMntE6hMYmV0qRgo1_ackars6okGZhs-1744772433579-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        vary:
+          - Origin
+        x-request-id:
+          - req_9054ff9a98f3d9d89420f77a53eb4d3d
+      status:
+        code: 401
+        message: Unauthorized
+  - request:
+      body:
+        '{"messages":[{"role":"user","content":"Hello!"},{"role":"assistant","content":null,"function_call":null,"tool_calls":[{"id":"call_QO7PSgLwGGXeS2rA5TBp183c","type":"function","function":{"arguments":"{\"message\":
+        \"Hi there! How can I assist you today?\"}","name":"talk"}}]},{"role":"tool","content":"Hi
+        there! How can I assist you today?","name":"talk","tool_call_id":"call_QO7PSgLwGGXeS2rA5TBp183c"}],"model":"gpt-4o","n":1,"tool_choice":"required","tools":[{"type":"function","function":{"name":"talk","description":"Say
+        something to me.","parameters":{"type":"object","properties":{"message":{"description":"what
+        you want to say","title":"Message","type":"string"}},"required":["message"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "697"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.65.2
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.65.2
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.4
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAwAAAP//jFPBbtswDL37KzSekyGx09b1ZcB62LqhGLYV6GEpDEWiHS2ypEl0NyPI
+          vw+2k9hJM2A+GAKfHvn4SG0jxkBJyBiINSdROT19/2DuTey+fHhsUv9wZxpX2V+JK2K6459g0jLs
+          6icKOrDeCls5jaSs6WHhkRO2Wec3i8XNTbxIkg6orETd0kpH04WdxrN4MZ2l09n1nri2SmCAjP2I
+          GGNs2/1biUbiH8jYbHKIVBgCLxGy4yXGwFvdRoCHoAJxQzAZQGENoWlVm1rrEUDW6lxwrYfC/bcd
+          nQefuNa58t9SybU3X6/i4mN4/L56uf+c1HJUr0/duE5QURtx9GeEH+PZWTHGwPCq4xLXmzMeY8B9
+          WVdoqNUM2+XBjyVkS3hCLWyFb9jTmhP7bWstWWNrptUGGVnWZmR8ZWtiZCVv3i1hBycFdtGl8/PI
+          NI9FHbh+7SY3xhJvm+rsfN4ju+PktC2dt6twRoVCGRXWuUceOkPGc4kOQjoJUJ+MHpy3laOc7Aa7
+          ordJnxSGxRzA+GoPkiWuh/h8nk4upMslElfdahy3UXCxRjlQh63ktVR2BESj1l+ruZS7b1+Z8n/S
+          D4AQ6Ahl7jxKJU47Hq55bN/tv64dTe4EQ0D/ogTmpNC345BY8Fr3TwpCEwirvFCmRO+86t4VFC6/
+          jYv5AtPrNIFoF/0FAAD//wMARjd67mAEAAA=
+      headers:
+        CF-RAY:
+          - 93106ede6bf5f7b1-LAX
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 16 Apr 2025 03:00:34 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=4FVmVLGIWba9co7mWyDJqerPfL94qIvch_w4fBDY4Qk-1744772434-1.0.1.1-peaClC99YfNXvbp0Bj6KCCU6dv2mZQkrdV4HyrtSveVcbcIfoDw4Wz5sIiWcmP4wmXSfOTm3Pwc80bx7g9lXW91KczHimjZAqG7nVb_OWH4;
+            path=/; expires=Wed, 16-Apr-25 03:30:34 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=lx4UOVJIcOo65NkoGQqmdwuiUoiOCi_c8GWF2rN3DDw-1744772434412-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "645"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        x-ratelimit-limit-requests:
+          - "10000"
+        x-ratelimit-limit-tokens:
+          - "30000000"
+        x-ratelimit-remaining-requests:
+          - "9999"
+        x-ratelimit-remaining-tokens:
+          - "29999984"
+        x-ratelimit-reset-requests:
+          - 6ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_1d6fd13a98f8b78b81108a4bf44c63ca
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -134,7 +134,6 @@ async def test_fallbacks_working(fallback: bool) -> None:
     rollout_manager = RolloutManager(
         agent,
         catch_agent_failures=fallback,
-        catch_env_failures=True,
         callbacks=[callback],
     )
     if fallback:

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 import pytest
 from aviary.core import Environment, Frame, Message, Tool, ToolRequestMessage
+from litellm import AuthenticationError
 from pydantic import BaseModel
 
 from ldp.agent import Agent, SimpleAgent, SimpleAgentState
@@ -80,6 +81,71 @@ async def test_rollout(training: bool) -> None:
             assert traj.traj_id == rehydrated_traj.traj_id
 
     assert all(v == 2 for v in callback.fn_invocations.values())
+
+
+# @pytest.mark.vcr
+@pytest.mark.parametrize("fallback", [True, False])
+@pytest.mark.asyncio
+async def test_fallbacks_working(fallback: bool) -> None:
+    AGENT_MODEL_LIST = [
+        {
+            "model_name": "openai/gpt-4o-mini",
+            "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "abc123"},
+        },
+        {
+            "model_name": "openai/gpt-4o",
+            "litellm_params": {
+                "model": "openai/gpt-4o",
+            },
+        },
+    ]
+    AGENT_ROUTER_KWARGS: dict[str, bool | list[dict[str, list[str]]]] = {
+        "set_verbose": True,
+    }
+    if fallback:
+        AGENT_ROUTER_KWARGS["fallbacks"] = [
+            {
+                "openai/gpt-4o-mini": [
+                    "openai/gpt-4o",
+                ]
+            }
+        ]
+
+    AGENT_CONFIG = {
+        "llm_model": {
+            "name": "openai/gpt-4o-mini",
+            "config": {
+                "model_list": AGENT_MODEL_LIST,
+                "router_kwargs": AGENT_ROUTER_KWARGS,
+            },
+        }
+    }
+    if fallback:
+        AGENT_CONFIG["llm_model"]["config"]["fallbacks"] = [  # type: ignore[index]
+            {
+                "openai/gpt-4o-mini": [
+                    "openai/gpt-4o",
+                ]
+            }
+        ]
+    agent = SimpleAgent(**AGENT_CONFIG)
+    callback = DummyCallback()
+
+    rollout_manager = RolloutManager(
+        agent,
+        catch_agent_failures=fallback,
+        catch_env_failures=True,
+        callbacks=[callback],
+    )
+    if fallback:
+        assert await rollout_manager.sample_trajectories(
+            environments=[DummyEnv()], max_steps=2
+        )
+    else:
+        with pytest.raises(AuthenticationError):
+            await rollout_manager.sample_trajectories(
+                environments=[DummyEnv()], max_steps=2
+            )
 
 
 async def adeepcopy(x):  # noqa: RUF029

--- a/tests/test_rollouts.py
+++ b/tests/test_rollouts.py
@@ -83,7 +83,7 @@ async def test_rollout(training: bool) -> None:
     assert all(v == 2 for v in callback.fn_invocations.values())
 
 
-# @pytest.mark.vcr
+@pytest.mark.vcr
 @pytest.mark.parametrize("fallback", [True, False])
 @pytest.mark.asyncio
 async def test_fallbacks_working(fallback: bool) -> None:


### PR DESCRIPTION
We re-use our agent's input `llm_model` configuration in both the `LLMModel` instantiation and in our `call` kwargs. These have some overlapping, but otherwise different arguments. We could split these into different configs, but this would be a big LDP change because it changes the call signature on an LLM op's forward function. 

So, we're just making this such that an Agent can actually define an llm configuration and not break if any inputs are being used for the router config which aren't supported as `call` kwargs. 

As a little clean up -- 🧹  we had a couple places with mutated kwargs, I am using deep copies to fix this. 