### PR TITLE
Use router also for embeddings

### DIFF
--- a/packages/lmi/src/lmi/embeddings.py
+++ b/packages/lmi/src/lmi/embeddings.py
@@ -95,10 +95,7 @@ class LiteLLMEmbeddingModel(EmbeddingModel):
     def router(self) -> litellm.Router:
         if self._router is None:
             router_kwargs: dict = self.config.get("router_kwargs", {})
-            if (
-                self.config.get("pass_through_router")
-                or "model_list" not in self.config
-            ):
+            if self.config.get("pass_through_router"):
                 self._router = PassThroughRouter(**router_kwargs)
             else:
                 self._router = litellm.Router(

--- a/packages/lmi/src/lmi/embeddings.py
+++ b/packages/lmi/src/lmi/embeddings.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from lmi.constants import CHARACTERS_PER_TOKEN_ASSUMPTION, MODEL_COST_MAP
 from lmi.cost_tracker import track_costs
-from lmi.rate_limiter import GLOBAL_LIMITER
 from lmi.llms import PassThroughRouter
+from lmi.rate_limiter import GLOBAL_LIMITER
 from lmi.utils import get_litellm_retrying_config
 
 

--- a/packages/lmi/src/lmi/embeddings.py
+++ b/packages/lmi/src/lmi/embeddings.py
@@ -95,7 +95,10 @@ class LiteLLMEmbeddingModel(EmbeddingModel):
     def router(self) -> litellm.Router:
         if self._router is None:
             router_kwargs: dict = self.config.get("router_kwargs", {})
-            if self.config.get("pass_through_router") or "model_list" not in self.config:
+            if (
+                self.config.get("pass_through_router")
+                or "model_list" not in self.config
+            ):
                 self._router = PassThroughRouter(**router_kwargs)
             else:
                 self._router = litellm.Router(

--- a/packages/lmi/src/lmi/embeddings.py
+++ b/packages/lmi/src/lmi/embeddings.py
@@ -95,8 +95,7 @@ class LiteLLMEmbeddingModel(EmbeddingModel):
     def router(self) -> litellm.Router:
         if self._router is None:
             router_kwargs: dict = self.config.get("router_kwargs", {})
-            if self.config.get("pass_through_router")
-                or "model_list" not in self.config:
+            if self.config.get("pass_through_router") or "model_list" not in self.config:
                 self._router = PassThroughRouter(**router_kwargs)
             else:
                 self._router = litellm.Router(

--- a/packages/lmi/src/lmi/embeddings.py
+++ b/packages/lmi/src/lmi/embeddings.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from lmi.constants import CHARACTERS_PER_TOKEN_ASSUMPTION, MODEL_COST_MAP
 from lmi.cost_tracker import track_costs
 from lmi.rate_limiter import GLOBAL_LIMITER
+from lmi.llms import PassThroughRouter
 from lmi.utils import get_litellm_retrying_config
 
 
@@ -94,7 +95,8 @@ class LiteLLMEmbeddingModel(EmbeddingModel):
     def router(self) -> litellm.Router:
         if self._router is None:
             router_kwargs: dict = self.config.get("router_kwargs", {})
-            if self.config.get("pass_through_router"):
+            if self.config.get("pass_through_router")
+                or "model_list" not in self.config:
                 self._router = PassThroughRouter(**router_kwargs)
             else:
                 self._router = litellm.Router(

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -504,6 +504,9 @@ class PassThroughRouter(litellm.Router):  # TODO: add rate_limited
     async def acompletion(self, *args, **kwargs):
         return await litellm.acompletion(*args, **(self._default_kwargs | kwargs))
 
+    async def aembedding(self, *args, **kwargs):
+        return await litellm.aembedding(*args, **(self._default_kwargs | kwargs))
+
 
 class LiteLLMModel(LLMModel):
     """A wrapper around the litellm library."""

--- a/packages/lmi/tests/cassettes/TestLiteLLMEmbeddingModel.test_router_usage[with-router].yaml
+++ b/packages/lmi/tests/cassettes/TestLiteLLMEmbeddingModel.test_router_usage[with-router].yaml
@@ -1,0 +1,110 @@
+interactions:
+  - request:
+      body: '{"input":["test"],"model":"text-embedding-3-small","dimensions":8,"encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "93"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.75.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.75.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "15.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.8
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1SOuwrCQBBF+/2KYdoYMKiFCxYWdgFFsFAR2bhr2LiPYEZNFP9dshEfzRR3Dvee
+          BwNAnxXqQMgBja4Ie20mBQnksGUAAI9w/0hlMyWldnnAw1M7qWrk0P8kX4gDNnZVXCmaN0U9XvpZ
+          5EalvjY3StL+ZWpEJDfD4yK/3dfpcIKh4ckAdsHGeqlMW0KqpvhTGw/iygpjOuVLJXKF/G2L5dnb
+          kvbkT8pVyCHptJA8CfMTs3boyV4AAAD//wMAcmMJtwoBAAA=
+      headers:
+        CF-RAY:
+          - 94ed1b709e89ed3f-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 12 Jun 2025 23:25:24 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=DuAaF.z7XVgnjUqVim6D1vK_tyxlvMLWzJQ7hZf9M_w-1749770724-1.0.1.1-WK3ecjU7ZG70Mlik8NUwp1N6XMhQamAwE7ifwqHKbiylpHobdBRYmca3BGrUuYPvPXjc790ejuFeDsXfJjaxLxgYGrV6ubT0q1rpYo7_qwI;
+            path=/; expires=Thu, 12-Jun-25 23:55:24 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=kRf9DwgT0gwKrDWGXEkvFyXi_iHxisxT3dstHuYjbHY-1749770724038-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-3-small
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "65"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-547f96dd47-bcrht
+        x-envoy-upstream-service-time:
+          - "67"
+        x-ratelimit-limit-requests:
+          - "200000"
+        x-ratelimit-limit-tokens:
+          - "200000000"
+        x-ratelimit-remaining-requests:
+          - "199998"
+        x-ratelimit-remaining-tokens:
+          - "199999999"
+        x-ratelimit-reset-requests:
+          - 0s
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_1ebf5398bcd8c616b0e00dda93bfdf60
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/packages/lmi/tests/cassettes/TestLiteLLMEmbeddingModel.test_router_usage[without-router].yaml
+++ b/packages/lmi/tests/cassettes/TestLiteLLMEmbeddingModel.test_router_usage[without-router].yaml
@@ -1,0 +1,110 @@
+interactions:
+  - request:
+      body: '{"input":["test"],"model":"text-embedding-3-small","dimensions":8,"encoding_format":"base64"}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "93"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.75.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.75.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "15.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.8
+      method: POST
+      uri: https://api.openai.com/v1/embeddings
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA1SOywrCMBBF9/mKYbZatD4x4EZwZ1FxoSAiqYmlNU3EjlJa+u/SVKpuZnHncO8p
+          GQDaMFEXQg6o44ywW2dSkEAORwYAULr7R6o0VFLGJnK4e8ZGqhw59NvkC3HAYLtNXslgVySFv7PL
+          zmS6iF+9aO2v+ibU+04UBteNGc8O09EcXUPFAE7OJrVS6bqEVE5eW+sNvSwVWjfKz0xECvnHFu8P
+          m97pTPamTIYc/EYLyZLQPzGrhyr2BgAA//8DAKYa9SUKAQAA
+      headers:
+        CF-RAY:
+          - 94ed1b719aed1742-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 12 Jun 2025 23:25:24 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=D2TTjOyddgZVgaFjKLo3HbD2iLcK_nAbJPQ4oMz8ZlE-1749770724-1.0.1.1-Hk5xwOp6Q2vzEUDcm6P001JA8Qi1NmZTA1qez1eWPoAy7fbMdLHZfNBFdTGab.ELDR_k6CFYcsCzZufk2asRxynQGC9V6QW3c5vtZtytvKM;
+            path=/; expires=Thu, 12-Jun-25 23:55:24 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=rYo0bbjMA0yYJzjvb2YdIMcIKLFYZ1BW6NN9h9_FwSI-1749770724526-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - text-embedding-3-small
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "338"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-655cd7d454-zz5ff
+        x-envoy-upstream-service-time:
+          - "343"
+        x-ratelimit-limit-requests:
+          - "200000"
+        x-ratelimit-limit-tokens:
+          - "200000000"
+        x-ratelimit-remaining-requests:
+          - "199998"
+        x-ratelimit-remaining-tokens:
+          - "199999999"
+        x-ratelimit-reset-requests:
+          - 0s
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_b8c7dc05227cdbf2cf9641950f626ad4
+      status:
+        code: 200
+        message: OK
+version: 1


### PR DESCRIPTION
Currently, embeddings just call litellm and thus don't provide the same configuration possibilities as the other completion endpoints. To fix this, a router is now used similar to the other calls so that one can use eg the following for azure-hosted:
```python
embedding = "text-embedding-3-small"
embedding_config = {
    "model_list": [
        {
            "model_name": embedding,
            "litellm_params": {
                "model": "azure/text-embedding-3-small",  # azure/<your deployment name>
                "api_key": os.getenv("AZURE_API_KEY"),
                "api_version": "2024-04-01-preview",
                "api_base": os.getenv(
                    "AZURE_API_BASE"
                ),  # eg. https://openai-gpt-4-test-v-1.openai.azure.com/
            },
        },
    ]
}
```