### PR TITLE
Updating Renovate config to allow Python 3.13 but downpin `torch<2.6`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,9 +27,9 @@
       automerge: true,
     },
     {
-      // TODO: remove after torch supports Python 3.13
-      matchPackageNames: ["python"],
-      allowedVersions: "<=3.12",
+      // TODO: remove after https://github.com/pytorch/pytorch/issues/152292
+      matchPackageNames: ["torch"],
+      allowedVersions: "<2.6",
     },
   ],
 }


### PR DESCRIPTION
See PR title

https://github.com/Future-House/ldp/pull/176 missed removing Renovate's <= Python 3.12 constraint