### PR TITLE
`LLMModel.call_single` validating just one result

### DIFF
--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -377,7 +377,10 @@ class LLMModel(ABC, BaseModel):
             messages, callbacks, name, output_type, tools, tool_choice, n=1, **kwargs
         )
         if not results:
-            raise ValueError("No results returned from call")
+            raise ValueError("No results returned from call.")
+        if len(results) > 1:
+            # Can be caused by issues like https://github.com/BerriAI/litellm/issues/12298
+            raise ValueError(f"Got {len(results)} results when expecting just one.")
         return results[0]
 
 

--- a/packages/lmi/tests/cassettes/TestTooling.test_multi_response_validation.yaml
+++ b/packages/lmi/tests/cassettes/TestTooling.test_multi_response_validation.yaml
@@ -1,0 +1,120 @@
+interactions:
+  - request:
+      body:
+        '{"model":"babbage-002","prompt":["Answer in a concise tone.","What is your
+        name?"],"max_tokens":4096,"n":1,"stream":false,"temperature":1.0}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "140"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 1.91.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 1.91.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.12.8
+      method: POST
+      uri: https://api.openai.com/v1/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6RTTWsbMRC9+1cMe2oha3s3TVN8CZSWJg2BfkEITQmz0nilWtIsktaOEvLfi2Q3
+          cUl76mW1zJs3781odD8BqLSsFlAJO5j67XDx+axZpju1xs1549+9P5X+0ny4Pb/8elUd5GzufpKI
+          mRHpNt4ItoOhqNltYeEJI+WKzfFRc/Rm/rptC2BZksm0DrsOe1q08/awnh/XbVOv2x1ZsRYUqgV8
+          nwAA3JcvbKUyFy5Qu4jaadcDgopxCIvZLLDQaDyhJD8VbGfSj32NUmqRnc0U+0ChRidrjop8jU5b
+          NKFesq89CV6TT8VCUdNO0m21gPljxHA/eO6yMzca8xhfaqeDuvGEgV02GCIPVUEfDv7VQgKHlkAH
+          +OQpGEpTuOIRLCYQaAxYKsAULhXGnJZ49IVzAmeAFj6yclP4pij9QSrha3ftTnkDbCSgp8zdsZpj
+          SIQ+ZGirmPGOBNvtNBOPrgeLDtjDhvOPxARdykcpXAxJzplg9IpAsnZ9rm94TRAZBpMZGFYUu2wL
+          nYQNRqEgKgLLa03h0aNFl6Dz5UpKl6BwTSe5M0/FXVSeCDpOAbQDm2CJVps0hRcDOaENBOFzde36
+          l/D3tpd5eHuNPxvbl7FLT/MoigcleJJ9XtHzvWj+ay8mAD/Kto8Be6oWuxWpBs92iDeRV+RywWYn
+          Uz09sT3w8DcaOaLZA161kyzyMPkFAAD//wMAigDPKdwDAAA=
+      headers:
+        CF-RAY:
+          - 9599b66add76fad2-SJC
+        Cache-Control:
+          - no-cache, must-revalidate
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Thu, 03 Jul 2025 22:10:23 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - __cf_bm=Tu7X9QGDxDhrj.O_.PAmgdmKfZy0WhP3379iDc41FIA-1751580623-1.0.1.1-BlO_utSadc52lqf9YDADRuhfOdbldeOv3ksOAGSI1gPXOnYl7x.7BaTNCEJfJNjbGvmpiuoArXLYQEP3b48QveD45ShOnZWJIQmcfPee3cw;
+            path=/; expires=Thu, 03-Jul-25 22:40:23 GMT; domain=.api.openai.com; HttpOnly;
+            Secure; SameSite=None
+          - _cfuvid=T9OChXVaNw0Zsyg4k9xQJyReXJlzbgd0h8tY_eIuUcM-1751580623173-0.0.1.1-604800000;
+            path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - X-Request-ID
+        alt-svc:
+          - h3=":443"; ma=86400
+        cf-cache-status:
+          - DYNAMIC
+        openai-model:
+          - babbage:2023-07-21-v2
+        openai-organization:
+          - future-house-xr4tdh
+        openai-processing-ms:
+          - "526"
+        openai-version:
+          - "2020-10-01"
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        via:
+          - envoy-router-79c9cd8ff5-tk5fv
+        x-envoy-upstream-service-time:
+          - "529"
+        x-ratelimit-limit-requests:
+          - "3000"
+        x-ratelimit-limit-tokens:
+          - "250000"
+        x-ratelimit-remaining-requests:
+          - "2999"
+        x-ratelimit-remaining-tokens:
+          - "249988"
+        x-ratelimit-reset-requests:
+          - 20ms
+        x-ratelimit-reset-tokens:
+          - 2ms
+        x-request-id:
+          - req_021d93e0917fc006c8a7a875ce0de8ee
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/packages/lmi/tests/test_llms.py
+++ b/packages/lmi/tests/test_llms.py
@@ -811,6 +811,20 @@ class TestTooling:
             assert isinstance(result.messages[0], ToolRequestMessage)
             assert not result.messages[0].tool_calls
 
+    @pytest.mark.asyncio
+    @pytest.mark.vcr
+    async def test_multi_response_validation(self) -> None:
+        model = LiteLLMModel(name="text-completion-openai/babbage-002")
+        with pytest.raises(ValueError, match="2 results"):
+            # Confirming https://github.com/BerriAI/litellm/issues/12298
+            # does not silently pass through LMI
+            await model.call_single(
+                messages=[
+                    Message(role="system", content="Answer in a concise tone."),
+                    Message(content="What is your name?"),
+                ]
+            )
+
 
 class TestReasoning:
     @pytest.mark.parametrize(


### PR DESCRIPTION
It turns out `LLMModel.call_single` + OpenAI `babbage-002` can give 2+ responses due to https://github.com/BerriAI/litellm/issues/12298.

We could take two actions here:

1. Attempt to auto-resolve the issue, by giving the last choice
2. Loudly fail

I decided to take option 2, which is the safest route.