### PR TITLE
Specifying `default=` in `EvaluatorConfig.num_eval_iterations`

### DIFF
--- a/src/ldp/alg/runners.py
+++ b/src/ldp/alg/runners.py
@@ -77,7 +77,7 @@ class EvaluatorConfig(BaseModel):
 
     batch_size: int = 1
     num_eval_iterations: int | None = Field(
-        None,
+        default=None,
         description=(
             "Number of eval iterations. "
             "If not provided, will exhaust the dataset. "


### PR DESCRIPTION
Without this, PyCharm was giving me an IDE warning:

> Parameter 'num_eval_iterations' unfilled

![image](https://github.com/user-attachments/assets/996406b2-5b70-4f79-8b5c-680863d4fb85)
