### PR TITLE
Better typing/docs on `LLMModel`, removed dead `prepare_args`

### DIFF
--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -151,8 +151,10 @@ def validate_json_completion(
 
 
 def prepare_args(
-    func: Callable, completion: str, name: str | None
-) -> tuple[tuple, dict]:
+    func: Callable[..., Any] | Callable[..., Awaitable],
+    completion: str,
+    name: str | None,
+) -> tuple[tuple[str, ...], dict[str, Any]]:
     with contextlib.suppress(TypeError):
         if "name" in signature(func).parameters:
             return (completion,), {"name": name}

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -235,14 +235,17 @@ class LLMModel(ABC, BaseModel):
     ) -> list[LLMResult]:
         """Call the LLM model with the given messages and configuration.
 
-        messages: A list of messages to send to the language model.
-        callbacks: A list of callback functions to execute
-        name: Optional name for the result.
-        output_type: The type of the output.
-        tools: A list of tools to use.
-        tool_choice: The tool choice to use.
+        Args:
+            messages: A list of messages to send to the language model.
+            callbacks: A list of callback functions to execute.
+            name: Optional name for the result.
+            output_type: The type of the output.
+            tools: A list of tools to use.
+            tool_choice: The tool choice to use.
+            kwargs: Additional keyword arguments for the chat completion.
 
-        Results: A list of LLMResult objects containing the result of the call.
+        Returns:
+            A list of LLMResult objects containing the result of the call.
 
         Raises:
             ValueError: If the LLM type is unknown.

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -23,6 +23,7 @@ from collections.abc import (
     Coroutine,
     Iterable,
     Mapping,
+    Sequence,
 )
 from enum import StrEnum
 from inspect import isasyncgenfunction, isawaitable, signature
@@ -226,7 +227,7 @@ class LLMModel(ABC, BaseModel):
     async def call(  # noqa: C901, PLR0915
         self,
         messages: list[Message],
-        callbacks: Iterable[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         name: str | None = None,
         output_type: type[BaseModel] | TypeAdapter | JSONSchema | None = None,
         tools: list[Tool] | None = None,
@@ -371,7 +372,7 @@ class LLMModel(ABC, BaseModel):
     async def call_single(
         self,
         messages: list[Message],
-        callbacks: Iterable[Callable] | None = None,
+        callbacks: Sequence[Callable] | None = None,
         name: str | None = None,
         output_type: type[BaseModel] | TypeAdapter | JSONSchema | None = None,
         tools: list[Tool] | None = None,

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -227,7 +227,9 @@ class LLMModel(ABC, BaseModel):
     async def call(  # noqa: C901, PLR0915
         self,
         messages: list[Message],
-        callbacks: Sequence[Callable] | None = None,
+        callbacks: (
+            Sequence[Callable[..., Any] | Callable[..., Awaitable]] | None
+        ) = None,
         name: str | None = None,
         output_type: type[BaseModel] | TypeAdapter | JSONSchema | None = None,
         tools: list[Tool] | None = None,
@@ -372,7 +374,9 @@ class LLMModel(ABC, BaseModel):
     async def call_single(
         self,
         messages: list[Message],
-        callbacks: Sequence[Callable] | None = None,
+        callbacks: (
+            Sequence[Callable[..., Any] | Callable[..., Awaitable]] | None
+        ) = None,
         name: str | None = None,
         output_type: type[BaseModel] | TypeAdapter | JSONSchema | None = None,
         tools: list[Tool] | None = None,

--- a/packages/lmi/src/lmi/utils.py
+++ b/packages/lmi/src/lmi/utils.py
@@ -3,8 +3,7 @@ import contextlib
 import logging
 import logging.config
 import os
-from collections.abc import Awaitable, Callable, Iterable
-from inspect import signature
+from collections.abc import Awaitable, Iterable
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import parse_qs, urlencode, urlparse
 
@@ -50,15 +49,6 @@ def configure_llm_logs() -> None:
 def get_litellm_retrying_config(timeout: float = 60.0) -> dict[str, Any]:
     """Get retrying configuration for litellm.acompletion and litellm.aembedding."""
     return {"num_retries": 3, "timeout": timeout}
-
-
-def prepare_args(
-    func: Callable, completion: str, name: str | None = None
-) -> tuple[tuple, dict]:
-    with contextlib.suppress(TypeError):
-        if "name" in signature(func).parameters:
-            return (completion,), {"name": name}
-    return (completion,), {}
 
 
 def partial_format(value: str, **formats: dict[str, Any]) -> str:

--- a/packages/lmi/src/lmi/utils.py
+++ b/packages/lmi/src/lmi/utils.py
@@ -16,7 +16,7 @@ except ImportError:
     tqdm = None  # type: ignore[assignment,misc]
 
 if TYPE_CHECKING:
-    import vcr.request  # type: ignore[import-untyped]
+    import vcr.request
 
 
 def configure_llm_logs() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ module = [
     "pydot",
     "transformers.*",  # SEE: https://github.com/huggingface/transformers/pull/18485
     "tree",  # SEE: https://github.com/google-deepmind/tree/issues/84
+    "vcr.*",  # SEE: https://github.com/kevin1024/vcrpy/issues/780
 ]
 
 [tool.pylint]


### PR DESCRIPTION
- Type hinted `callbacks` to help users
    - Moved from `Iterable` to `Sequence` to enforce ordering
- Fixed bad docstring in `LLMModel.call`
- Removed dead code `prepare_args` (it's duplicated in `llms.py`
- Properly ignoring `vcrpy` in typing