### PR TITLE
Make the callbacks in cost_tracker async

### DIFF
--- a/packages/lmi/src/lmi/cost_tracker.py
+++ b/packages/lmi/src/lmi/cost_tracker.py
@@ -20,7 +20,6 @@ class CostTracker:
         self.enabled = contextvars.ContextVar[bool]("track_costs", default=False)
         # Not a contextvar because I can't imagine a scenario where you'd want more fine-grained control
         self.report_every_usd = 1.0
-        # Support async callbacks only
         self._callbacks: list[Callable[[LLMResponse], Awaitable]] = []
 
     def add_callback(self, callback: Callable[[LLMResponse], Awaitable]) -> None:

--- a/packages/lmi/tests/test_cost_tracking.py
+++ b/packages/lmi/tests/test_cost_tracking.py
@@ -164,7 +164,7 @@ class TestCostTrackerCallback:
     @pytest.mark.asyncio
     async def test_callback_succeeds(self):
         mock_response = MagicMock(cost=0.01)
-        callback_calls: list[Any] = []
+        callback_calls = []
 
         async def async_callback(response):  # noqa: RUF029
             callback_calls.append(response)

--- a/packages/lmi/tests/test_cost_tracking.py
+++ b/packages/lmi/tests/test_cost_tracking.py
@@ -163,7 +163,6 @@ class TestLiteLLMModel:
 class TestCostTrackerCallback:
     @pytest.mark.asyncio
     async def test_callback_succeeds(self):
-        """Test that the record method handles both cost tracking and callbacks."""
         mock_response = MagicMock(cost=0.01)
         callback_calls: list[Any] = []
 
@@ -184,7 +183,6 @@ class TestCostTrackerCallback:
 
     @pytest.mark.asyncio
     async def test_callback_failure_does_not_break_tracker(self, caplog):
-        """Test that a failing callback doesn't break the cost tracker."""
         mock_response = MagicMock(cost=0.01)
         failing_callback = MagicMock(side_effect=Exception("Callback failed"))
         GLOBAL_COST_TRACKER.add_callback(failing_callback)
@@ -203,7 +201,6 @@ class TestCostTrackerCallback:
 
     @pytest.mark.asyncio
     async def test_multiple_callbacks_with_one_failing(self, caplog):
-        """Test that one failing callback doesn't prevent other callbacks from running."""
         mock_response = MagicMock(cost=0.01)
         failing_callback = MagicMock(side_effect=Exception("Callback failed"))
         succeeding_callback = MagicMock()
@@ -225,7 +222,6 @@ class TestCostTrackerCallback:
 
     @pytest.mark.asyncio
     async def test_async_context_with_stream_wrapper(self):
-        """Test that callbacks work with TrackedStreamWrapper in async context."""
         mock_stream = MagicMock()
         mock_response = MagicMock(cost=0.01)
         mock_stream.__anext__ = AsyncMock(return_value=mock_response)

--- a/packages/lmi/tests/test_cost_tracking.py
+++ b/packages/lmi/tests/test_cost_tracking.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -162,24 +163,6 @@ class TestLiteLLMModel:
 
 class TestCostTrackerCallback:
     @pytest.mark.asyncio
-    async def test_callback_succeeds(self):
-        mock_response = MagicMock(cost=0.01)
-
-        callback_calls: list[Any] = []
-        GLOBAL_COST_TRACKER.add_callback(callback_calls.append)
-
-        with (
-            cost_tracking_ctx(),
-            patch("litellm.cost_calculator.completion_cost", return_value=0.01),
-        ):
-            GLOBAL_COST_TRACKER.record(mock_response)
-
-            assert len(callback_calls) == 1
-            assert callback_calls[0] == mock_response
-
-            assert GLOBAL_COST_TRACKER.lifetime_cost_usd > 0
-
-    @pytest.mark.asyncio
     async def test_callback_failure_does_not_break_tracker(self, caplog):
         """Test that a failing callback doesn't break the cost tracker."""
         mock_response = MagicMock(cost=0.01)
@@ -190,7 +173,7 @@ class TestCostTrackerCallback:
             cost_tracking_ctx(),
             patch("litellm.cost_calculator.completion_cost", return_value=0.01),
         ):
-            GLOBAL_COST_TRACKER.record(mock_response)
+            await GLOBAL_COST_TRACKER.record(mock_response)
 
             failing_callback.assert_called_once_with(mock_response)
 
@@ -212,10 +195,80 @@ class TestCostTrackerCallback:
             cost_tracking_ctx(),
             patch("litellm.cost_calculator.completion_cost", return_value=0.01),
         ):
-            GLOBAL_COST_TRACKER.record(mock_response)
+            await GLOBAL_COST_TRACKER.record(mock_response)
 
             failing_callback.assert_called_once_with(mock_response)
             succeeding_callback.assert_called_once_with(mock_response)
 
             assert "Callback failed during cost tracking" in caplog.text
+            assert GLOBAL_COST_TRACKER.lifetime_cost_usd > 0
+
+    @pytest.mark.asyncio
+    async def test_async_context_with_stream_wrapper(self):
+        """Test that callbacks work with TrackedStreamWrapper in async context."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        # Create a mock stream
+        mock_stream = MagicMock()
+        mock_response = MagicMock(cost=0.01)
+        mock_stream.__anext__ = AsyncMock(return_value=mock_response)
+
+        # Create TrackedStreamWrapper
+        from lmi.cost_tracker import TrackedStreamWrapper
+
+        wrapper = TrackedStreamWrapper(mock_stream)
+
+        callback_calls: list[Any] = []
+
+        async def async_callback(response):
+            await asyncio.sleep(1)
+            callback_calls.append(response)
+
+        GLOBAL_COST_TRACKER.add_callback(async_callback)
+
+        with (
+            cost_tracking_ctx(),
+            patch("litellm.cost_calculator.completion_cost", return_value=0.01),
+        ):
+            # Test async iteration
+            result = await anext(wrapper)
+
+            assert result == mock_response
+            assert len(callback_calls) == 1
+            assert callback_calls[0] == mock_response
+            assert GLOBAL_COST_TRACKER.lifetime_cost_usd > 0
+
+    def test_sync_context_with_stream_wrapper(self):
+        """Test that callbacks work with TrackedStreamWrapper in sync context."""
+        from unittest.mock import MagicMock
+
+        # Create a mock stream
+        mock_stream = MagicMock()
+        mock_response = MagicMock(cost=0.01)
+        mock_stream.__next__ = MagicMock(return_value=mock_response)
+
+        # Create TrackedStreamWrapper
+        from lmi.cost_tracker import TrackedStreamWrapper
+
+        wrapper = TrackedStreamWrapper(mock_stream)
+
+        callback_calls: list[Any] = []
+
+        async def async_callback(response):
+            await asyncio.sleep(1)
+            callback_calls.append(response)
+
+        GLOBAL_COST_TRACKER.add_callback(async_callback)
+
+        with (
+            cost_tracking_ctx(),
+            patch("litellm.cost_calculator.completion_cost", return_value=0.01),
+        ):
+            # Test sync iteration - this will run callbacks synchronously via asyncio.run()
+            result = next(wrapper)
+
+            assert result == mock_response
+            # The callback should have been called synchronously
+            assert len(callback_calls) == 1
+            assert callback_calls[0] == mock_response
             assert GLOBAL_COST_TRACKER.lifetime_cost_usd > 0

--- a/packages/lmi/tests/test_cost_tracking.py
+++ b/packages/lmi/tests/test_cost_tracking.py
@@ -228,7 +228,7 @@ class TestCostTrackerCallback:
 
         wrapper = TrackedStreamWrapper(mock_stream)
 
-        callback_calls: list[Any] = []
+        callback_calls = []
 
         async def async_callback(response):  # noqa: RUF029
             callback_calls.append(response)


### PR DESCRIPTION
Making the callbacks in cost_tracker.py asynchronous: job-event calls run after every LLM request, so we schedule them on the event loop to avoid blocking the main execution path and adding latency.