### PR TITLE
Add support for a messages sliding window

### DIFF
--- a/src/ldp/agent/react_agent.py
+++ b/src/ldp/agent/react_agent.py
@@ -117,6 +117,16 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
         description="See SimpleAgentState.hide_old_env_states.",
     )
 
+    hide_old_action_content: bool = Field(
+        default=False,
+        description="See SimpleAgentState.hide_old_action_content.",
+    )
+
+    sliding_window: int = Field(
+        default=0,
+        description="Number of previous trajectory transitions to keep in the state. 0 means all previous transitions.",
+    )
+
     @classmethod
     def make_act_agent(cls, **kwargs) -> Self:
         single_prompt = kwargs.pop("single_prompt", False)
@@ -151,7 +161,10 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
 
     async def init_state(self, tools: list[Tool]) -> SimpleAgentState:
         return SimpleAgentState(
-            tools=tools, hide_old_env_states=self.hide_old_env_states
+            tools=tools,
+            hide_old_env_states=self.hide_old_env_states,
+            hide_old_action_content=self.hide_old_action_content,
+            sliding_window=self.sliding_window,
         )
 
     @staticmethod

--- a/src/ldp/agent/react_agent.py
+++ b/src/ldp/agent/react_agent.py
@@ -122,8 +122,8 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
         description="See SimpleAgentState.hide_old_action_content.",
     )
 
-    sliding_window: int = Field(
-        default=-1,
+    sliding_window: int | None = Field(
+        default=None,
         description=SimpleAgentState.model_fields["sliding_window"].description,
     )
 

--- a/src/ldp/agent/react_agent.py
+++ b/src/ldp/agent/react_agent.py
@@ -124,7 +124,7 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
 
     sliding_window: int | None = Field(
         default=None,
-        description=SimpleAgentState.model_fields["sliding_window"].description,
+        description="See SimpleAgentState.sliding_window.",
     )
 
     @classmethod

--- a/src/ldp/agent/react_agent.py
+++ b/src/ldp/agent/react_agent.py
@@ -123,8 +123,8 @@ class ReActAgent(BaseModel, Agent[SimpleAgentState]):
     )
 
     sliding_window: int = Field(
-        default=0,
-        description="Number of previous trajectory transitions to keep in the state. 0 means all previous transitions.",
+        default=-1,
+        description=SimpleAgentState.model_fields["sliding_window"].description,
     )
 
     @classmethod

--- a/src/ldp/agent/simple_agent.py
+++ b/src/ldp/agent/simple_agent.py
@@ -47,8 +47,8 @@ class SimpleAgentState(BaseModel):
         description="If True, will hide the content of old ToolRequestMessages.",
     )
     sliding_window: int = Field(
-        default=0,
-        description="Number of previous trajectory transitions to keep in the state. 0 means all previous transitions.",
+        default=-1,
+        description="Number of previous trajectory transitions to keep. -1 means all previous transitions.",
     )
 
     def get_next_state(
@@ -144,8 +144,8 @@ class SimpleAgent(BaseModel, Agent[SimpleAgentState]):
     )
 
     sliding_window: int = Field(
-        default=0,
-        description="Number of previous trajectory transitions to keep in the state. 0 means all previous transitions.",
+        default=-1,
+        description="Number of previous trajectory transitions to keep. -1 means all previous transitions.",
     )
 
     def __init__(self, **kwargs):

--- a/src/ldp/agent/simple_agent.py
+++ b/src/ldp/agent/simple_agent.py
@@ -143,7 +143,7 @@ class SimpleAgent(BaseModel, Agent[SimpleAgentState]):
 
     sliding_window: int | None = Field(
         default=None,
-        description="Number of previous trajectory transitions to keep. None means all previous transitions.",
+        description="See SimpleAgentState.sliding_window.",
     )
 
     def __init__(self, **kwargs):

--- a/src/ldp/agent/simple_agent.py
+++ b/src/ldp/agent/simple_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from itertools import chain
 from typing import Any, Self, cast
 
 from aviary.core import Message, Tool, ToolRequestMessage, ToolResponseMessage
@@ -85,11 +86,7 @@ class SimpleAgentState(BaseModel):
             old_messages = (
                 msg_blocks[0]  # keep system messages + user message
                 + [HiddenTransitionsMessage()]  # hide intermediate transitions
-                + [
-                    msg
-                    for sublist in msg_blocks[1:][-self.sliding_window :]
-                    for msg in sublist
-                ]
+                + list(chain.from_iterable(msg_blocks[1:][-self.sliding_window :]))
             )
 
         if hide_old_env_states:

--- a/src/ldp/utils.py
+++ b/src/ldp/utils.py
@@ -120,8 +120,8 @@ def split_message_transitions(list_of_messages: list[Message]) -> list[list[Mess
     Break down messages into transitions: [(system, user), (tool request, tool response, env state), ...].
 
     Blocks end when either:
-    - EnvStateMessage → ToolRequestMessage transition occurs
-    - ToolResponseMessage → ToolRequestMessage transition occurs
+    - an EnvStateMessage to ToolRequestMessage transition occurs
+    - a ToolResponseMessage to ToolRequestMessage transition occurs
 
     Args:
         list_of_messages: The list of messages to break down.

--- a/src/ldp/utils.py
+++ b/src/ldp/utils.py
@@ -117,7 +117,7 @@ def format_error_details(error: Exception) -> str:
 
 def split_message_transitions(list_of_messages: list[Message]) -> list[list[Message]]:
     """
-    Break down messages into transitions: (system, (user, assistant, tool), ...).
+    Break down messages into transitions: [(system, user), (tool request, tool response, env state), ...].
 
     Args:
         list_of_messages: The list of messages to break down.
@@ -138,7 +138,7 @@ def split_message_transitions(list_of_messages: list[Message]) -> list[list[Mess
         i += 1
     filtered_messages.append(system_block)
 
-    # Process remaining messages, breaking on (EnvStateMessage, ToolRequestMessage, ToolResponseMessage) blocks
+    # Process remaining messages in (ToolRequestMessage's, ToolResponseMessage's, EnvStateMessage) blocks
     current_block: list[Message] = []
     for j in range(i, len(list_of_messages)):
         msg = list_of_messages[j]
@@ -148,7 +148,6 @@ def split_message_transitions(list_of_messages: list[Message]) -> list[list[Mess
             and isinstance(msg, ToolRequestMessage)
             and current_block
         ):
-            # End current block and start a new one
             filtered_messages.append(current_block)
             current_block = [msg]
         else:

--- a/src/ldp/utils.py
+++ b/src/ldp/utils.py
@@ -121,7 +121,7 @@ def split_message_transitions(list_of_messages: list[Message]) -> list[list[Mess
 
     Blocks end when either:
     - EnvStateMessage → ToolRequestMessage transition occurs
-    - ToolResponseMessage → ToolRequestMessage transition occurs (when EnvStateMessage is skipped)
+    - ToolResponseMessage → ToolRequestMessage transition occurs
 
     Args:
         list_of_messages: The list of messages to break down.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -142,7 +142,7 @@ class TestSimpleAgent:
             "hide_old_action_content": False,
             "llm_model": {"name": model_name, "temperature": 0.1},
             "sys_prompt": None,
-            "sliding_window": -1,
+            "sliding_window": None,
         }
 
         # Check we can get the LLM results to sum cost and count tokens

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -142,7 +142,7 @@ class TestSimpleAgent:
             "hide_old_action_content": False,
             "llm_model": {"name": model_name, "temperature": 0.1},
             "sys_prompt": None,
-            "sliding_window": 0,
+            "sliding_window": -1,
         }
 
         # Check we can get the LLM results to sum cost and count tokens

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -142,6 +142,7 @@ class TestSimpleAgent:
             "hide_old_action_content": False,
             "llm_model": {"name": model_name, "temperature": 0.1},
             "sys_prompt": None,
+            "sliding_window": 0,
         }
 
         # Check we can get the LLM results to sum cost and count tokens

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,27 +74,26 @@ def test_split_message_transitions():
 
     result = split_message_transitions(messages)
 
-    # Should have 4 blocks total
     assert len(result) == 4
 
-    # Block 1: System messages + initial user message
+    # Block 1:
     assert len(result[0]) == 2
     assert result[0][0].role == "system"
     assert result[0][1].role == "user"
 
-    # Block 2: First sequence ending with EnvStateMessage
+    # Block 2:
     assert len(result[1]) == 3
     assert isinstance(result[1][0], ToolRequestMessage)
     assert isinstance(result[1][1], ToolResponseMessage)
     assert isinstance(result[1][2], EnvStateMessage)
 
-    # Block 3: Second sequence ending with EnvStateMessage
+    # Block 3:
     assert len(result[2]) == 3
     assert isinstance(result[2][0], ToolRequestMessage)
     assert isinstance(result[2][1], ToolResponseMessage)
     assert isinstance(result[2][2], EnvStateMessage)
 
-    # Block 4: Third sequence (no EnvStateMessage→ToolRequestMessage after it)
+    # Block 4:
     assert len(result[3]) == 2
     assert isinstance(result[3][0], ToolRequestMessage)
     assert isinstance(result[3][1], ToolResponseMessage)


### PR DESCRIPTION
Some environments might not need to keep track of all the previous messages history (e.g. envs that keep a plan in the env state and keep updating it).

This PR allows agents to define a sliding window to only keep in context the last N chat transitions.