### PR TITLE
lmi: support TLS Redis (rediss://) in GlobalRateLimiter

### DIFF
--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -107,12 +107,15 @@ class GlobalRateLimiter:
         Args:
             rate_config: Optional dictionary mapping (namespace, primary_key) tuples to
                 RateLimitItem instances. If not provided, the default RATE_CONFIG is used.
-            use_in_memory: If True, use in-memory storage instead of Redis, even if
-                Redis URL is available.
+            use_in_memory: If True, force in-memory storage even if a Redis URL
+                is available. When False (the default), in-memory storage is still
+                used as a fallback if no Redis URL is provided via `redis_url` or
+                the `REDIS_URL` environment variable.
             redis_url: Optional Redis URL to use for storage. If not provided, the
-                REDIS_URL environment variable will be used. This parameter allows
-                direct specification of the Redis URL without relying on environment
-                variables.
+                `REDIS_URL` environment variable will be used. Supports
+                `redis://host:port` (plaintext), `rediss://host:port` (TLS, e.g.
+                AWS ElastiCache with in-transit encryption), and bare `host:port`
+                (treated as plaintext).
         """
         self._rate_config = RATE_CONFIG if rate_config is None else rate_config
         self._redis_url = redis_url or os.environ.get("REDIS_URL")

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -116,7 +116,10 @@ class GlobalRateLimiter:
         """
         self.rate_config = RATE_CONFIG if rate_config is None else rate_config
         self.use_in_memory = use_in_memory
-        self.redis_url = redis_url
+        self.redis_url = redis_url or os.environ.get("REDIS_URL", "")
+        self.redis_tls = self.redis_url.startswith("rediss://")
+        self.redis_scheme = "async+rediss" if self.redis_tls else "async+redis"
+        self.redis_bare_url = self._strip_scheme(self.redis_url)
         self._storage: RedisStorage | MemoryStorage | None = None
         self._rate_limiter: MovingWindowRateLimiter | None = None
         self._current_ip: str | None = None
@@ -134,25 +137,8 @@ class GlobalRateLimiter:
         return None
 
     @staticmethod
-    def _wants_tls(redis_url: str) -> bool:
-        if redis_url.startswith("rediss://"):
-            return True
-        if redis_url.startswith("redis://"):
-            return False
-        return os.environ.get("REDIS_USE_TLS", "").lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
-
-    @staticmethod
     def _strip_scheme(redis_url: str) -> str:
-        if redis_url.startswith("rediss://"):
-            return redis_url[len("rediss://") :]
-        if redis_url.startswith("redis://"):
-            return redis_url[len("redis://") :]
-        return redis_url
+        return redis_url.removeprefix("rediss://").removeprefix("redis://")
 
     async def outbount_ip(self) -> str:
         if self._current_ip is None:
@@ -171,13 +157,10 @@ class GlobalRateLimiter:
     @property
     def storage(self) -> RedisStorage | MemoryStorage:
         if self._storage is None:
-            redis_url = self.redis_url or os.environ.get("REDIS_URL")
-            if redis_url and not self.use_in_memory:
-                use_tls = self._wants_tls(redis_url)
-                bare_url = self._strip_scheme(redis_url)
-                scheme = "rediss" if use_tls else "redis"
-                self._storage = RedisStorage(f"async+{scheme}://{bare_url}")
-                logger.info("Connected to redis instance for rate limiting.")
+            if self.redis_url and not self.use_in_memory:
+                conn = f"{self.redis_scheme}://{self.redis_bare_url}"
+                self._storage = RedisStorage(conn)
+                logger.info(f"Connected to redis instance for rate limiting: {conn}")
             else:
                 self._storage = MemoryStorage()
                 logger.info("Using in-memory rate limiter.")
@@ -293,47 +276,19 @@ class GlobalRateLimiter:
         self, cursor_scan_count: int = 100
     ) -> list[tuple[RateLimitItem, tuple[str, str | MatchAllInputs]]]:
         """Returns a list of current RateLimitItems with tuples of namespace and primary key."""
-        redis_url = self.redis_url or os.environ.get("REDIS_URL", ":")
-        if redis_url is None:
-            raise ValueError("Redis URL is not set correctly.")
-
-        # Support scheme-prefixed URLs (redis://, rediss://) and bare
-        # "host:port" / ":password@host:port" forms. The bare-form URL needs
-        # a synthetic `redis://` prefix before urlparse can extract
-        # host/port/password; TLS selection comes from the explicit scheme
-        # or a narrow REDIS_USE_TLS env override for bare URLs.
-        use_tls = self._wants_tls(redis_url)
-        bare_url = self._strip_scheme(redis_url)
-
-        try:
-            parsed = urlparse(f"redis://{bare_url}")
-        except ValueError as exc:
-            raise ValueError(
-                f"Failed to parse host and port from Redis URL {redis_url!r},"
-                " correctly pass at initialization or set env variable REDIS_URL."
-            ) from exc
-
-        if not (parsed.hostname and parsed.port):
-            raise ValueError(
-                f"Failed to parse host and port from Redis URL {redis_url!r},"
-                " correctly pass at initialization or set env variable REDIS_URL."
-            )
-
-        storage = self.storage
-        if not isinstance(storage, RedisStorage):
+        # urlparse requires a scheme prefix to extract host/port/password from
+        # bare "host:port" or ":password@host:port" URLs.
+        parsed = urlparse(f"{self.redis_scheme}://{self.redis_bare_url}")
+        if not isinstance(self.storage, RedisStorage):
             raise NotImplementedError(
                 "get_rate_limit_keys only works with RedisStorage."
             )
 
-        # ssl=use_tls is required because the bare host/port constructor
-        # does not inherit TLS config from the URL-based storage client.
-        # Without it, a TLS-only Redis endpoint accepts the TCP handshake
-        # and then hangs waiting for a ClientHello that never arrives.
         client = Redis(
             host=parsed.hostname,
             port=parsed.port,
             password=parsed.password,
-            ssl=use_tls,
+            ssl=self.redis_tls,
         )
 
         try:
@@ -342,7 +297,7 @@ class GlobalRateLimiter:
             while cursor:
                 cursor, keys = await client.scan(
                     int(cursor),
-                    match=f"{storage.bridge.key_prefix}*",
+                    match=f"{self.storage.bridge.key_prefix}*",
                     count=cursor_scan_count,
                 )
                 matching_keys.extend(list(keys))

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -116,7 +116,9 @@ class GlobalRateLimiter:
         """
         self.rate_config = RATE_CONFIG if rate_config is None else rate_config
         self.use_in_memory = use_in_memory
-        self.redis_url = redis_url or os.environ.get("REDIS_URL", "")
+        self.redis_url = redis_url or os.environ.get("REDIS_URL")
+        if not self.redis_url:
+            raise ValueError("You must specify a `redis_url` or set the REDIS_URL environment variable.")
         self.redis_tls = self.redis_url.startswith("rediss://")
         # Redis over SSL when possible.
         self.redis_scheme = "async+rediss" if self.redis_tls else "async+redis"
@@ -280,12 +282,10 @@ class GlobalRateLimiter:
         # urlparse requires a scheme prefix to extract host/port/password from
         # bare "host:port" or ":password@host:port" URLs.
         try:
-            parsed = urlparse(f"{self.redis_scheme}://{self.redis_bare_url}")
+            url = f"{self.redis_scheme}://{self.redis_bare_url}"
+            parsed = urlparse(url)
         except ValueError as exc:
-            raise ValueError(
-                f"Failed to parse host and port from Redis URL {self.redis_bare_url!r},"
-                " correctly pass at initialization or set env variable REDIS_URL."
-            ) from exc
+            raise ValueError(f"Failed to parse host and port from Redis URL {url!r}.") from exc
 
         if not isinstance(self.storage, RedisStorage):
             raise NotImplementedError(

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -114,15 +114,17 @@ class GlobalRateLimiter:
                 direct specification of the Redis URL without relying on environment
                 variables.
         """
-        self.rate_config = RATE_CONFIG if rate_config is None else rate_config
-        self.use_in_memory = use_in_memory
-        self.redis_url = redis_url or os.environ.get("REDIS_URL")
-        if not self.redis_url and not use_in_memory:
-            raise ValueError("You must specify a `redis_url` or set the REDIS_URL environment variable.")
-        self.redis_tls = self.redis_url.startswith("rediss://") if self.redis_url else False
+        self._rate_config = RATE_CONFIG if rate_config is None else rate_config
+        self._redis_url = redis_url or os.environ.get("REDIS_URL")
+        self._use_in_memory = use_in_memory or not self._redis_url
+        self._redis_tls = (
+            self._redis_url.startswith("rediss://") if self._redis_url else False
+        )
         # Redis over SSL when possible.
-        self.redis_scheme = "async+rediss" if self.redis_tls else "async+redis"
-        self.redis_bare_url = self._strip_scheme(self.redis_url) if self.redis_url else ""
+        self._redis_scheme = "async+rediss" if self._redis_tls else "async+redis"
+        self._redis_bare_url = (
+            self._strip_scheme(self._redis_url) if self._redis_url else ""
+        )
         self._storage: RedisStorage | MemoryStorage | None = None
         self._rate_limiter: MovingWindowRateLimiter | None = None
         self._current_ip: str | None = None
@@ -160,13 +162,13 @@ class GlobalRateLimiter:
     @property
     def storage(self) -> RedisStorage | MemoryStorage:
         if self._storage is None:
-            if self.redis_url and not self.use_in_memory:
-                conn = f"{self.redis_scheme}://{self.redis_bare_url}"
-                self._storage = RedisStorage(conn)
-                logger.info(f"Connected to redis instance for rate limiting: {conn}")
-            else:
+            if self._use_in_memory:
                 self._storage = MemoryStorage()
                 logger.info("Using in-memory rate limiter.")
+            else:
+                conn = f"{self._redis_scheme}://{self._redis_bare_url}"
+                self._storage = RedisStorage(conn)
+                logger.info(f"Connected to redis instance for rate limiting: {conn}")
 
         return self._storage
 
@@ -231,27 +233,27 @@ class GlobalRateLimiter:
 
         # here we want to use namespace_w_machine_id_stripped -- the rate should be shared
         # this needs to be checked first, since it's more specific than the stub machine id
-        if (namespace_w_machine_id_stripped, primary_key) in self.rate_config:
+        if (namespace_w_machine_id_stripped, primary_key) in self._rate_config:
             return (
-                self.rate_config[namespace_w_machine_id_stripped, primary_key],
+                self._rate_config[namespace_w_machine_id_stripped, primary_key],
                 namespace_w_machine_id_stripped,
             )
         # we keep the old namespace if we match on the namespace_w_stub_machine_id
-        if (namespace_w_stub_machine_id, primary_key) in self.rate_config:
+        if (namespace_w_stub_machine_id, primary_key) in self._rate_config:
             return (
-                self.rate_config[namespace_w_stub_machine_id, primary_key],
+                self._rate_config[namespace_w_stub_machine_id, primary_key],
                 namespace,
             )
         # again we only want the original namespace, keep the old namespace
-        if (namespace_w_stub_machine_id, MATCH_ALL) in self.rate_config:
+        if (namespace_w_stub_machine_id, MATCH_ALL) in self._rate_config:
             return (
-                self.rate_config[namespace_w_stub_machine_id, MATCH_ALL],
+                self._rate_config[namespace_w_stub_machine_id, MATCH_ALL],
                 namespace,
             )
         # again we want to use the stripped namespace if it matches
-        if (namespace_w_machine_id_stripped, MATCH_ALL) in self.rate_config:
+        if (namespace_w_machine_id_stripped, MATCH_ALL) in self._rate_config:
             return (
-                self.rate_config[namespace_w_machine_id_stripped, MATCH_ALL],
+                self._rate_config[namespace_w_machine_id_stripped, MATCH_ALL],
                 namespace_w_machine_id_stripped,
             )
         return FALLBACK_RATE_LIMIT, namespace
@@ -282,10 +284,12 @@ class GlobalRateLimiter:
         # urlparse requires a scheme prefix to extract host/port/password from
         # bare "host:port" or ":password@host:port" URLs.
         try:
-            url = f"{self.redis_scheme}://{self.redis_bare_url}"
+            url = f"{self._redis_scheme}://{self._redis_bare_url}"
             parsed = urlparse(url)
         except ValueError as exc:
-            raise ValueError(f"Failed to parse host and port from Redis URL {url!r}.") from exc
+            raise ValueError(
+                f"Failed to parse host and port from Redis URL {url!r}."
+            ) from exc
 
         if not isinstance(self.storage, RedisStorage):
             raise NotImplementedError(
@@ -296,7 +300,7 @@ class GlobalRateLimiter:
             host=parsed.hostname,
             port=parsed.port,
             password=parsed.password,
-            ssl=self.redis_tls,
+            ssl=self._redis_tls,
         )
 
         try:
@@ -327,10 +331,9 @@ class GlobalRateLimiter:
     async def get_limit_keys(
         self,
     ) -> list[tuple[RateLimitItem, tuple[str, str | MatchAllInputs]]]:
-        redis_url = self.redis_url or os.environ.get("REDIS_URL")
-        if redis_url and not self.use_in_memory:
-            return await self.get_rate_limit_keys()
-        return self.get_in_memory_limit_keys()
+        if self._use_in_memory:
+            return self.get_in_memory_limit_keys()
+        return await self.get_rate_limit_keys()
 
     async def rate_limit_status(self):
         limit_status = {}
@@ -443,4 +446,4 @@ class GlobalRateLimiter:
             acquire_timeout = max(acquire_timeout - elapsed, 1.0)
 
 
-GLOBAL_LIMITER = GlobalRateLimiter(use_in_memory=not os.environ.get("REDIS_URL"))
+GLOBAL_LIMITER = GlobalRateLimiter()

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -117,12 +117,12 @@ class GlobalRateLimiter:
         self.rate_config = RATE_CONFIG if rate_config is None else rate_config
         self.use_in_memory = use_in_memory
         self.redis_url = redis_url or os.environ.get("REDIS_URL")
-        if not self.redis_url:
+        if not self.redis_url and not use_in_memory:
             raise ValueError("You must specify a `redis_url` or set the REDIS_URL environment variable.")
-        self.redis_tls = self.redis_url.startswith("rediss://")
+        self.redis_tls = self.redis_url.startswith("rediss://") if self.redis_url else False
         # Redis over SSL when possible.
         self.redis_scheme = "async+rediss" if self.redis_tls else "async+redis"
-        self.redis_bare_url = self._strip_scheme(self.redis_url)
+        self.redis_bare_url = self._strip_scheme(self.redis_url) if self.redis_url else ""
         self._storage: RedisStorage | MemoryStorage | None = None
         self._rate_limiter: MovingWindowRateLimiter | None = None
         self._current_ip: str | None = None
@@ -443,4 +443,4 @@ class GlobalRateLimiter:
             acquire_timeout = max(acquire_timeout - elapsed, 1.0)
 
 
-GLOBAL_LIMITER = GlobalRateLimiter()
+GLOBAL_LIMITER = GlobalRateLimiter(use_in_memory=not os.environ.get("REDIS_URL"))

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -118,6 +118,7 @@ class GlobalRateLimiter:
         self.use_in_memory = use_in_memory
         self.redis_url = redis_url or os.environ.get("REDIS_URL", "")
         self.redis_tls = self.redis_url.startswith("rediss://")
+        # Redis over SSL when possible.
         self.redis_scheme = "async+rediss" if self.redis_tls else "async+redis"
         self.redis_bare_url = self._strip_scheme(self.redis_url)
         self._storage: RedisStorage | MemoryStorage | None = None
@@ -278,7 +279,14 @@ class GlobalRateLimiter:
         """Returns a list of current RateLimitItems with tuples of namespace and primary key."""
         # urlparse requires a scheme prefix to extract host/port/password from
         # bare "host:port" or ":password@host:port" URLs.
-        parsed = urlparse(f"{self.redis_scheme}://{self.redis_bare_url}")
+        try:
+            parsed = urlparse(f"{self.redis_scheme}://{self.redis_bare_url}")
+        except ValueError as exc:
+            raise ValueError(
+                f"Failed to parse host and port from Redis URL {self.redis_bare_url!r},"
+                " correctly pass at initialization or set env variable REDIS_URL."
+            ) from exc
+
         if not isinstance(self.storage, RedisStorage):
             raise NotImplementedError(
                 "get_rate_limit_keys only works with RedisStorage."

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -133,6 +133,27 @@ class GlobalRateLimiter:
             logger.warning(f"Error occurred while connecting to {url}.", exc_info=True)
         return None
 
+    @staticmethod
+    def _wants_tls(redis_url: str) -> bool:
+        if redis_url.startswith("rediss://"):
+            return True
+        if redis_url.startswith("redis://"):
+            return False
+        return os.environ.get("REDIS_USE_TLS", "").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+    @staticmethod
+    def _strip_scheme(redis_url: str) -> str:
+        if redis_url.startswith("rediss://"):
+            return redis_url[len("rediss://") :]
+        if redis_url.startswith("redis://"):
+            return redis_url[len("redis://") :]
+        return redis_url
+
     async def outbount_ip(self) -> str:
         if self._current_ip is None:
             async with aiohttp.ClientSession() as session:
@@ -152,7 +173,10 @@ class GlobalRateLimiter:
         if self._storage is None:
             redis_url = self.redis_url or os.environ.get("REDIS_URL")
             if redis_url and not self.use_in_memory:
-                self._storage = RedisStorage(f"async+redis://{redis_url}")
+                use_tls = self._wants_tls(redis_url)
+                bare_url = self._strip_scheme(redis_url)
+                scheme = "rediss" if use_tls else "redis"
+                self._storage = RedisStorage(f"async+{scheme}://{bare_url}")
                 logger.info("Connected to redis instance for rate limiting.")
             else:
                 self._storage = MemoryStorage()
@@ -273,11 +297,16 @@ class GlobalRateLimiter:
         if redis_url is None:
             raise ValueError("Redis URL is not set correctly.")
 
-        # parse redis_url which may be "host:port" or ":password@host:port"
-        # the prefixed : looks like a bug waiting to happen but this is how
-        # the redis client handles uris without a username this way
+        # Support scheme-prefixed URLs (redis://, rediss://) and bare
+        # "host:port" / ":password@host:port" forms. The bare-form URL needs
+        # a synthetic `redis://` prefix before urlparse can extract
+        # host/port/password; TLS selection comes from the explicit scheme
+        # or a narrow REDIS_USE_TLS env override for bare URLs.
+        use_tls = self._wants_tls(redis_url)
+        bare_url = self._strip_scheme(redis_url)
+
         try:
-            parsed = urlparse(f"redis://{redis_url}")
+            parsed = urlparse(f"redis://{bare_url}")
         except ValueError as exc:
             raise ValueError(
                 f"Failed to parse host and port from Redis URL {redis_url!r},"
@@ -296,7 +325,16 @@ class GlobalRateLimiter:
                 "get_rate_limit_keys only works with RedisStorage."
             )
 
-        client = Redis(host=parsed.hostname, port=parsed.port, password=parsed.password)
+        # ssl=use_tls is required because the bare host/port constructor
+        # does not inherit TLS config from the URL-based storage client.
+        # Without it, a TLS-only Redis endpoint accepts the TCP handshake
+        # and then hangs waiting for a ClientHello that never arrives.
+        client = Redis(
+            host=parsed.hostname,
+            port=parsed.port,
+            password=parsed.password,
+            ssl=use_tls,
+        )
 
         try:
             cursor: int | bytes = b"0"

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -396,17 +396,15 @@ async def test_rpm_concurrent_requests(llm_config_w_request_limits: dict[str, An
 
 class TestGlobalRateLimiter:
     @pytest.mark.parametrize(
-        ("redis_url_factory", "tls_env", "expected_redis_kwargs"),
+        ("redis_url_factory", "expected_redis_kwargs"),
         [
             pytest.param(
                 lambda: "10.58.188.212:6379",
-                None,
                 {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
                 id="plain-host-port",
             ),
             pytest.param(
                 lambda: f":{uuid.uuid4()}@10.58.188.212:6379",
-                None,
                 lambda url: {
                     "host": "10.58.188.212",
                     "port": 6379,
@@ -417,40 +415,22 @@ class TestGlobalRateLimiter:
             ),
             pytest.param(
                 lambda: "redis://10.58.188.212:6379",
-                None,
                 {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
                 id="redis-scheme",
             ),
             pytest.param(
                 lambda: "rediss://10.58.188.212:6379",
-                None,
                 {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": True},
                 id="rediss-scheme",
-            ),
-            pytest.param(
-                lambda: "10.58.188.212:6379",
-                "true",
-                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": True},
-                id="bare-host-port-env-tls-enabled",
-            ),
-            pytest.param(
-                lambda: "10.58.188.212:6379",
-                "0",
-                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
-                id="bare-host-port-env-tls-disabled",
             ),
         ],
     )
     @pytest.mark.asyncio
     async def test_get_rate_limit_keys_parses_redis_url(
-        self, redis_url_factory, tls_env, expected_redis_kwargs, monkeypatch
+        self, redis_url_factory, expected_redis_kwargs
     ) -> None:
         """Test that get_rate_limit_keys parses Redis URLs and configures TLS correctly."""
         redis_url = redis_url_factory()
-        if tls_env is None:
-            monkeypatch.delenv("REDIS_USE_TLS", raising=False)
-        else:
-            monkeypatch.setenv("REDIS_USE_TLS", tls_env)
         if callable(expected_redis_kwargs):
             expected_redis_kwargs = expected_redis_kwargs(redis_url)
         limiter = GlobalRateLimiter(redis_url=redis_url)
@@ -462,48 +442,28 @@ class TestGlobalRateLimiter:
             mock_redis_cls.assert_called_once_with(**expected_redis_kwargs)
 
     @pytest.mark.parametrize(
-        ("redis_url", "tls_env", "expected_storage_url"),
+        ("redis_url", "expected_storage_url"),
         [
             pytest.param(
                 "10.58.188.212:6379",
-                None,
                 "async+redis://10.58.188.212:6379",
                 id="plain-host-port",
             ),
             pytest.param(
                 "redis://10.58.188.212:6379",
-                None,
                 "async+redis://10.58.188.212:6379",
                 id="redis-scheme",
             ),
             pytest.param(
                 "rediss://10.58.188.212:6379",
-                None,
                 "async+rediss://10.58.188.212:6379",
                 id="rediss-scheme",
-            ),
-            pytest.param(
-                "10.58.188.212:6379",
-                "true",
-                "async+rediss://10.58.188.212:6379",
-                id="bare-host-port-env-tls-enabled",
-            ),
-            pytest.param(
-                "10.58.188.212:6379",
-                "0",
-                "async+redis://10.58.188.212:6379",
-                id="bare-host-port-env-tls-disabled",
             ),
         ],
     )
     def test_storage_uses_expected_redis_scheme(
-        self, redis_url, tls_env, expected_storage_url, monkeypatch
+        self, redis_url, expected_storage_url
     ) -> None:
-        if tls_env is None:
-            monkeypatch.delenv("REDIS_USE_TLS", raising=False)
-        else:
-            monkeypatch.setenv("REDIS_USE_TLS", tls_env)
-
         with patch("lmi.rate_limiter.RedisStorage") as mock_redis_storage:
             limiter = GlobalRateLimiter(redis_url=redis_url)
             _ = limiter.storage

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -429,7 +429,7 @@ class TestGlobalRateLimiter:
     async def test_get_rate_limit_keys_parses_redis_url(
         self, redis_url_factory, expected_redis_kwargs
     ) -> None:
-        """Test that get_rate_limit_keys parses Redis URLs and configures TLS correctly."""
+        """Test that get_rate_limit_keys correctly parses both plain and password-protected Redis URLs."""
         redis_url = redis_url_factory()
         if callable(expected_redis_kwargs):
             expected_redis_kwargs = expected_redis_kwargs(redis_url)

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -396,30 +396,61 @@ async def test_rpm_concurrent_requests(llm_config_w_request_limits: dict[str, An
 
 class TestGlobalRateLimiter:
     @pytest.mark.parametrize(
-        ("redis_url_factory", "expected_redis_kwargs"),
+        ("redis_url_factory", "tls_env", "expected_redis_kwargs"),
         [
             pytest.param(
                 lambda: "10.58.188.212:6379",
-                {"host": "10.58.188.212", "port": 6379, "password": None},
+                None,
+                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
                 id="plain-host-port",
             ),
             pytest.param(
                 lambda: f":{uuid.uuid4()}@10.58.188.212:6379",
+                None,
                 lambda url: {
                     "host": "10.58.188.212",
                     "port": 6379,
                     "password": urlparse(f"redis://{url}").password,
+                    "ssl": False,
                 },
                 id="password-protected",
+            ),
+            pytest.param(
+                lambda: "redis://10.58.188.212:6379",
+                None,
+                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
+                id="redis-scheme",
+            ),
+            pytest.param(
+                lambda: "rediss://10.58.188.212:6379",
+                None,
+                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": True},
+                id="rediss-scheme",
+            ),
+            pytest.param(
+                lambda: "10.58.188.212:6379",
+                "true",
+                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": True},
+                id="bare-host-port-env-tls-enabled",
+            ),
+            pytest.param(
+                lambda: "10.58.188.212:6379",
+                "0",
+                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
+                id="bare-host-port-env-tls-disabled",
             ),
         ],
     )
     @pytest.mark.asyncio
     async def test_get_rate_limit_keys_parses_redis_url(
-        self, redis_url_factory, expected_redis_kwargs
+        self, redis_url_factory, tls_env, expected_redis_kwargs, monkeypatch
     ) -> None:
-        """Test that get_rate_limit_keys correctly parses both plain and password-protected Redis URLs."""
+        """Test that get_rate_limit_keys parses Redis URLs and configures TLS correctly."""
         redis_url = redis_url_factory()
+        if tls_env is None:
+            monkeypatch.delenv("REDIS_USE_TLS", raising=False)
+        else:
+            monkeypatch.setenv("REDIS_USE_TLS", tls_env)
         if callable(expected_redis_kwargs):
             expected_redis_kwargs = expected_redis_kwargs(redis_url)
         limiter = GlobalRateLimiter(redis_url=redis_url)
@@ -429,6 +460,54 @@ class TestGlobalRateLimiter:
             mock_client.quit = AsyncMock()
             await limiter.get_rate_limit_keys()
             mock_redis_cls.assert_called_once_with(**expected_redis_kwargs)
+
+    @pytest.mark.parametrize(
+        ("redis_url", "tls_env", "expected_storage_url"),
+        [
+            pytest.param(
+                "10.58.188.212:6379",
+                None,
+                "async+redis://10.58.188.212:6379",
+                id="plain-host-port",
+            ),
+            pytest.param(
+                "redis://10.58.188.212:6379",
+                None,
+                "async+redis://10.58.188.212:6379",
+                id="redis-scheme",
+            ),
+            pytest.param(
+                "rediss://10.58.188.212:6379",
+                None,
+                "async+rediss://10.58.188.212:6379",
+                id="rediss-scheme",
+            ),
+            pytest.param(
+                "10.58.188.212:6379",
+                "true",
+                "async+rediss://10.58.188.212:6379",
+                id="bare-host-port-env-tls-enabled",
+            ),
+            pytest.param(
+                "10.58.188.212:6379",
+                "0",
+                "async+redis://10.58.188.212:6379",
+                id="bare-host-port-env-tls-disabled",
+            ),
+        ],
+    )
+    def test_storage_uses_expected_redis_scheme(
+        self, redis_url, tls_env, expected_storage_url, monkeypatch
+    ) -> None:
+        if tls_env is None:
+            monkeypatch.delenv("REDIS_USE_TLS", raising=False)
+        else:
+            monkeypatch.setenv("REDIS_USE_TLS", tls_env)
+
+        with patch("lmi.rate_limiter.RedisStorage") as mock_redis_storage:
+            limiter = GlobalRateLimiter(redis_url=redis_url)
+            _ = limiter.storage
+            mock_redis_storage.assert_called_once_with(expected_storage_url)
 
     @pytest.mark.asyncio
     async def test_parsing_namespace(self) -> None:


### PR DESCRIPTION
## Summary

`GlobalRateLimiter` previously hardcoded `async+redis://` for the storage client (`rate_limiter.py:155`) and opened the `get_rate_limit_keys` SCAN client without any `ssl=` kwarg. Against a TLS-only Redis — e.g. AWS ElastiCache with in-transit encryption enabled — the TCP handshake succeeds but the server then hangs waiting for a ClientHello that never arrives. Symptom in the wild: `get_rate_limit_keys()` hangs during agent startup, blocking `_choose_model_based_on_limits` and every downstream rate-limited call.

This PR makes both Redis code paths scheme-aware and consistent:

- Two shared helpers — `_wants_tls(redis_url)` and `_strip_scheme(redis_url)` — decide TLS from an explicit `rediss://` / `redis://` scheme, or (for bare `host:port` URLs) from a `REDIS_USE_TLS` env var parsed as a whitelist (`1|true|yes|on`) rather than `bool()` (which would treat `"0"`/`"false"` as true).
- The storage property now builds `async+rediss://{host}:{port}` when TLS is required, instead of unconditionally prefixing `async+redis://`.
- `get_rate_limit_keys()` uses the same helpers and passes `ssl=<tls>` to the direct `coredis.Redis(...)` client.

## Behavior matrix

| `REDIS_URL`              | `REDIS_USE_TLS` | Storage URL                   | Scan client `ssl` |
|--------------------------|-----------------|-------------------------------|-------------------|
| `host:6379`              | unset           | `async+redis://host:6379`     | `False`           |
| `host:6379`              | `true`          | `async+rediss://host:6379`    | `True`            |
| `host:6379`              | `0` / `false`   | `async+redis://host:6379`     | `False`           |
| `redis://host:6379`      | any             | `async+redis://host:6379`     | `False`           |
| `rediss://host:6379`     | any             | `async+rediss://host:6379`    | `True`            |

The bare-host + no-env-var row is the GCP Memorystore path — unchanged.

## Test plan

- [x] `uv run --directory packages/lmi pytest tests/test_rate_limiter.py` → 38 passed
- [x] `uv run mypy packages/lmi/src/lmi/rate_limiter.py` → clean
- [x] `pre-commit run --files packages/lmi/src/lmi/rate_limiter.py packages/lmi/tests/test_rate_limiter.py` → all hooks pass (ruff, mypy, codespell, detect-secrets, blacken-docs)
- [x] New parametrized coverage for the scan client AND the storage URL across plain, `redis://`, `rediss://`, and both `REDIS_USE_TLS` directions (including the `"0"` regression case that `bool()` would have mishandled)
- [x] Validated end-to-end in a downstream service: a TLS-only ElastiCache endpoint that previously hung during `get_rate_limit_keys` now completes startup and proceeds to model selection.

## Follow-up

A downstream service (paperqa-server) currently carries a local override of `get_rate_limit_keys` that added `ssl=True` to the scan client. Once this lands and is released, that override can be dropped.