### PR TITLE
Filter `tool_parser` out of `LLMCallOp` kwargs and respect caller's `tool_choice`

### DIFF
--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -1181,10 +1181,18 @@ class LiteLLMModel(LLMModel):
             self.NO_TOOL_CHOICE,
         }:
             logger.warning(
-                f"Custom tool parser was provided."
-                f"Setting tool_choice parameter to {self.NO_TOOL_CHOICE}."
+                f"A custom tool_parser is set together with {tool_choice=}."
+                " There are two use cases:"
+                "\n- Custom tool parser meant to handle output from a model that"
+                " wasn't told to call tools. LMI used to auto-specify"
+                f" tool_choice={self.NO_TOOL_CHOICE!r} for this case,"
+                " but this denies the second case below, so we dropped it."
+                "\n- Custom tool parser meant to extract `<tool_call>` blocks"
+                " the model emits as text in `message.content` (e.g. vLLM served"
+                f" without --enable-auto-tool-choice): keep {tool_choice=}."
+                f" Rewriting to {self.NO_TOOL_CHOICE!r} would tell the model"
+                " not to call tools and starve the parser."
             )
-            kwargs["tool_choice"] = self.NO_TOOL_CHOICE
 
         completions = await track_costs(router.acompletion)(
             self.name, prompts, **kwargs

--- a/src/ldp/graph/common_ops.py
+++ b/src/ldp/graph/common_ops.py
@@ -6,7 +6,7 @@ import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from functools import lru_cache
-from typing import TYPE_CHECKING, Generic, TypeVar, cast, overload
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar, cast, overload
 
 import numpy as np
 import tenacity
@@ -218,6 +218,12 @@ class ResponseValidationError(Exception):
 class LLMCallOp(Op[Message]):
     """An operation for LLM calls interaction."""
 
+    # Use this lookup to filter out LLMModel.config items before LLMModel.call:
+    # - Remove keys that are not call parameters (e.g. router_kwargs).
+    # - Remove lmi-specific constructs like tool_parser. Propagating it to
+    #   litellm.acompletion would send a function object and break JSON encoding.
+    CONFIG_ONLY_KEYS: ClassVar[set[str]] = {"router_kwargs", "tool_parser"}
+
     def __init__(
         self,
         num_samples_logprob_estimate: int = 0,
@@ -294,10 +300,7 @@ class LLMCallOp(Op[Message]):
             messages=msgs,
             tools=tools,
             tool_choice=tool_choice,
-            # Since config is shared between our LLMModel and our `call` options
-            # we need to ensure we remove keys which work with LLMModel
-            # but not `call`.
-            **{k: v for k, v in config.items() if k != "router_kwargs"},
+            **{k: v for k, v in config.items() if k not in self.CONFIG_ONLY_KEYS},
         )
         if result.messages is None:
             raise ValueError("No messages returned")

--- a/tests/cassettes/TestLLMCallOp.test_tool_parser_with_required_tool_choice.yaml
+++ b/tests/cassettes/TestLLMCallOp.test_tool_parser_with_required_tool_choice.yaml
@@ -1,0 +1,114 @@
+interactions:
+  - request:
+      body:
+        '{"messages": [{"role": "user", "content": "Call echo with x=1"}], "model":
+        "gpt-4o-mini-2024-07-18", "n": 1, "temperature": 1.0, "tool_choice": "required",
+        "tools": [{"type": "function", "function": {"name": "echo", "description": "Echo
+        the integer back.", "parameters": {"type": "object", "properties": {"x": {"description":
+        "An integer to echo.", "title": "X", "type": "integer"}}, "required": ["x"]}}}]}'
+      headers:
+        accept:
+          - application/json
+        accept-encoding:
+          - gzip, deflate
+        connection:
+          - keep-alive
+        content-length:
+          - "373"
+        content-type:
+          - application/json
+        host:
+          - api.openai.com
+        user-agent:
+          - AsyncOpenAI/Python 2.24.0
+        x-stainless-arch:
+          - arm64
+        x-stainless-async:
+          - async:asyncio
+        x-stainless-lang:
+          - python
+        x-stainless-os:
+          - MacOS
+        x-stainless-package-version:
+          - 2.24.0
+        x-stainless-raw-response:
+          - "true"
+        x-stainless-read-timeout:
+          - "60.0"
+        x-stainless-retry-count:
+          - "0"
+        x-stainless-runtime:
+          - CPython
+        x-stainless-runtime-version:
+          - 3.13.5
+      method: POST
+      uri: https://api.openai.com/v1/chat/completions
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAA/6rmUlBQykxRslJQSs5ILEnOLcjRdcnIyC0LCQYAAAD//4xTTW+jMBC98ysqn8OK
+          QBua3rrSdjdSVa3UPVTaVsgxA3FrbGSbbqIo/33HJsEkTaVyQDBv3sybrzUs/txnj/W/TZpcUba6
+          W/xefn8gE8dQy1dg9sD6xhTywHIle5hpoBZc1Gmez7PkOp/nHmhUCcLR6tbGlypuuORxmqSXcZLH
+          0+s9e6U4A4Nuf/H34mLr306nLGGN5mRysDRgDK0BbQcnNGolnIVQY7ixVFoyCSBT0oJ00mUnxAiw
+          SomCUSFC4v7Zjr5Ds9CxYOnPBb39sf6VZU+bOlXs6XF2xx7kKF8fetN6QVUn2dCkET7Yb06SISZp
+          47mAXTnhIUp13TVYjtNMts9k/Uxupjty5LaLzn2/jErXUHWGio89oVIqS50035SXPbIb+i9U3Wq1
+          NCdUUuFczarANTC+rHF3o4MQL4F0RwMkGK5pbWHVG/ikV7M+KAk7FsBptgctyhTBPptPzkQrSrCU
+          +/kOK8VwsaEMzLBatCu5GgHRqPKPYs7F7qvnsv5K+AAwBi0eT9FqKDk7Lji4aXAX+Jnb0GMvmBjQ
+          73hSheWg3TRKqGgn+rsgZmMsNAWOrAbdau6Pg1RtMaMlZPMqryoS7aL/AAAA//8DACpxsLoqBAAA
+      headers:
+        Access-Control-Expose-Headers:
+          - X-Request-ID
+          - CF-Ray
+          - CF-Ray
+        CF-Cache-Status:
+          - DYNAMIC
+        CF-Ray:
+          - 9fee13ce7fc0fbec-SJC
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json
+        Date:
+          - Wed, 20 May 2026 20:26:38 GMT
+        Server:
+          - cloudflare
+        Set-Cookie:
+          - <FILTERED>
+        Strict-Transport-Security:
+          - max-age=31536000; includeSubDomains; preload
+        Transfer-Encoding:
+          - chunked
+        X-Content-Type-Options:
+          - nosniff
+        alt-svc:
+          - h3=":443"; ma=86400
+        openai-organization:
+          - <FILTERED>
+        openai-processing-ms:
+          - "640"
+        openai-project:
+          - <FILTERED>
+        openai-version:
+          - "2020-10-01"
+        x-openai-proxy-wasm:
+          - v0.1
+        x-ratelimit-limit-requests:
+          - "30000"
+        x-ratelimit-limit-tokens:
+          - "150000000"
+        x-ratelimit-remaining-requests:
+          - "29999"
+        x-ratelimit-remaining-tokens:
+          - "149999995"
+        x-ratelimit-reset-requests:
+          - 2ms
+        x-ratelimit-reset-tokens:
+          - 0s
+        x-request-id:
+          - req_3233ddb00018466e93b38f5fb00a7382
+      status:
+        code: 200
+        message: OK
+version: 1

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -12,6 +12,7 @@ import tree
 from aviary.core import DummyEnv, Message, Tool, ToolRequestMessage
 from lmi import CommonLLMNames, LLMResult
 from lmi import LiteLLMModel as LLMModel
+from lmi.utils import VCR_DEFAULT_MATCH_ON
 
 from ldp.graph import (
     CallID,
@@ -204,6 +205,41 @@ class TestLLMCallOp:
         llm_op = LLMCallOp(response_validator=StatefulValidator())
         with pytest.raises(tenacity.RetryError, match="ResponseValidationError"):
             await llm_op(config, msgs=[Message(content="Hello")])
+
+    @pytest.mark.vcr(match_on=[*VCR_DEFAULT_MATCH_ON, "body"])
+    @pytest.mark.asyncio
+    async def test_tool_parser_with_required_tool_choice(self) -> None:
+        def parse_text_tool_calls(
+            choice: litellm.utils.Choices,
+            tools: list[dict] | None,  # noqa: ARG001
+        ) -> Message:
+            # Stand-in for a vLLM-without-auto-tool-choice style parser that
+            # would extract <tool_call> blocks from message.content
+            return Message(role="assistant", content=choice.message.content)
+
+        def echo(x: int) -> int:
+            """Echo the integer back.
+
+            Args:
+                x: An integer to echo.
+            """
+            return x
+
+        config = {
+            "name": CommonLLMNames.OPENAI_TEST.value,
+            "tool_parser": parse_text_tool_calls,
+        }
+        llm_op = LLMCallOp()
+        async with compute_graph():
+            op_result = await llm_op(
+                config,
+                msgs=[Message(content="Call echo with x=1")],
+                tools=[Tool.from_function(echo)],
+            )
+
+        assert isinstance(op_result.value, Message), (
+            "Expected the custom tool_parser's Message back"
+        )
 
 
 class StatefulValidator:


### PR DESCRIPTION
## Summary

Two related defects fired together when a custom `tool_parser` was paired with `LLMCallOp`'s default `tool_choice='required'`. The fixes live on both sides of the LDP/LMI boundary; one shared regression test catches both.

## Bugs addressed

1. **`tool_parser` leaks into the litellm request body.** `LLMCallOp.forward` previously spread every `config` key (except `router_kwargs`) into the per-call kwargs. The `tool_parser` callable is an lmi-specific construct that `LiteLLMModel.maybe_set_config_attribute` lifts onto `model.tool_parser` off a deep copy — leaving the caller's dict still carrying the function. Spreading it sent the function object into litellm's request body and raised `Object of type function is not JSON serializable`.
2. **`tool_choice` is silently rewritten to `'none'`.** `LiteLLMModel.acompletion` forced any caller-supplied `tool_choice` (other than `None`/`'none'`) to `NO_TOOL_CHOICE` whenever `tool_parser` was set. That assumed a custom parser implies the caller wants the model told not to call tools, which silently broke the opposite valid setup (e.g. vLLM served without `--enable-auto-tool-choice`, where the model still emits `<tool_call>` blocks in `message.content` for a client-side parser to extract).

## Changes

- **LDP** — `LLMCallOp` now keeps a `CONFIG_ONLY_KEYS = {"router_kwargs", "tool_parser"}` class attribute and filters it out of the kwargs spread, with the rationale documented next to the set.
- **LMI** — `LiteLLMModel.acompletion` no longer rewrites `tool_choice`. The warning still fires when a non-`'none'` value is paired with a `tool_parser`, but now explains the two distinct caller intents (legacy free-text parsing vs. `<tool_call>` block extraction) and what to do in each case.
- **Test** — one VCR-recorded `LLMCallOp` test exercises the full LDP → LMI → litellm path with a custom parser and `default_tool_choice='required'`. Uses body-matching VCR (`match_on=[*VCR_DEFAULT_MATCH_ON, "body"]`) so a regressed request body fails to find a cassette entry instead of silently replaying the old one.

## Behavioral change to call out

The `tool_choice` override removal is a behavior change for callers who relied on lmi silently rewriting `'required'`/`'auto'` to `'none'`. The warning surfaces the situation; callers who want the old behavior should pass `tool_choice='none'` (or set `LLMCallOp(default_tool_choice='none')`) explicitly.