### PR TITLE
Avoided deptry fails on packages [CLD-320]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ ignore-words-list = "astroid,ser"
 skip = "**tests/cassettes/*,**/tests/cassettes/*"
 
 [tool.deptry]
-extend_exclude = ["packages/lmi"]
+extend_exclude = ["packages/*"]
 optional_dependencies_dev_groups = ["dev", "typing"]
 
 [tool.deptry.per_rule_ignores]
@@ -633,4 +633,4 @@ fhlmi = {workspace = true}
 ldp = {workspace = true}
 
 [tool.uv.workspace]
-members = ["packages/*"]
+members = ["packages/lmi"]


### PR DESCRIPTION
The CI creates a /docs directory inside ldp/packages that uv was trying to interpret as a package and failing.
Additionally, deptry in ldp fails when scanning packages/*. I excluded this url as lmi has it's own deptry step