### PR TITLE
fix(lmi): bound Redis I/O in GlobalRateLimiter [CLD-320]

### DIFF
--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -30,6 +30,8 @@ CROSSREF_BASE_URL = f"https://{CROSSREF_HOST}"
 
 GLOBAL_RATE_LIMITER_TIMEOUT = float(os.environ.get("RATE_LIMITER_TIMEOUT", "60"))
 
+RATE_LIMITER_REDIS_OP_TIMEOUT = 5.0
+
 MATCH_ALL = None
 MatchAllInputs: TypeAlias = Literal[None]  # noqa: PYI061
 MATCH_MACHINE_ID = "<machine_id>"
@@ -170,7 +172,11 @@ class GlobalRateLimiter:
                 logger.info("Using in-memory rate limiter.")
             else:
                 conn = f"{self._redis_scheme}://{self._redis_bare_url}"
-                self._storage = RedisStorage(conn)
+                self._storage = RedisStorage(
+                    conn,
+                    stream_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
+                    connect_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
+                )
                 logger.info(f"Connected to redis instance for rate limiting: {conn}")
 
         return self._storage
@@ -391,6 +397,10 @@ class GlobalRateLimiter:
             TimeoutError: if the acquire_timeout is exceeded.
             ValueError: if the weight exceeds the rate limit.
                 Only raised if raise_impossible_limits was specified.
+
+        Note:
+            If Redis is unreachable, the op raises a coredis RedisError (bounded by
+            RATE_LIMITER_REDIS_OP_TIMEOUT) that propagates instead of hanging.
         """
         namespace, primary_key = await self.parse_namespace_and_primary_key(
             namespace_and_key, machine_id=machine_id

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -14,7 +14,12 @@ from limits import RateLimitItemPerSecond
 from lmi.constants import CHARACTERS_PER_TOKEN_ASSUMPTION
 from lmi.embeddings import LiteLLMEmbeddingModel
 from lmi.llms import CommonLLMNames, LiteLLMModel
-from lmi.rate_limiter import CROSSREF_BASE_URL, FALLBACK_RATE_LIMIT, GlobalRateLimiter
+from lmi.rate_limiter import (
+    CROSSREF_BASE_URL,
+    FALLBACK_RATE_LIMIT,
+    RATE_LIMITER_REDIS_OP_TIMEOUT,
+    GlobalRateLimiter,
+)
 from lmi.types import LLMResult
 
 LLM_CONFIG_W_RATE_LIMITS = [
@@ -467,7 +472,12 @@ class TestGlobalRateLimiter:
         with patch("lmi.rate_limiter.RedisStorage") as mock_redis_storage:
             limiter = GlobalRateLimiter(redis_url=redis_url)
             _ = limiter.storage
-            mock_redis_storage.assert_called_once_with(expected_storage_url)
+            # timeouts must reach RedisStorage so a stalled connection can't hang
+            mock_redis_storage.assert_called_once_with(
+                expected_storage_url,
+                stream_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
+                connect_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
+            )
 
     @pytest.mark.asyncio
     async def test_parsing_namespace(self) -> None:


### PR DESCRIPTION
## Why

Agent trajectories were freezing forever, at random. Every LLM and embedding call goes through `GlobalRateLimiter.try_acquire`, which checks a Redis-backed rate limit. The coredis client was built with no socket timeout, so when an idle Redis connection got silently dropped (for example, an AWS NAT Gateway reaping the flow without sending a reset), the next Redis call blocked with nothing to break it. The existing `acquire_timeout` only bounds the polling sleep loop, not the Redis I/O, so the run hung indefinitely.

## What changed

Pass `stream_timeout` and `connect_timeout` to `RedisStorage`. These flow through `limits` to `coredis.Redis.from_url`, so a stalled op now raises a bounded error instead of hanging. The error propagates to the caller rather than freezing the trajectory.

This is a minimal alternative to #460, which builds fail-open behavior, in-memory degradation, and auto-recovery on top of the same root fix. This PR does only the part that stops the freeze.
