### PR TITLE
fix(lmi): require explicit scheme in Redis URL for GlobalRateLimiter [CLD-311]

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,3 +5,4 @@ Mayk Caldas <mayk@futurehouse.org> maykcaldas
 Michael Skarlinski <mskarlinski@futurehouse.org> mskarlin <12701035+mskarlin@users.noreply.github.com>
 Ryan-Rhys Griffiths <ryan@futurehouse.org> <ryangriff123@gmail.com>
 Siddharth Narayanan <sid@futurehouse.org> <sidnarayanan@users.noreply.github.com>
+Yann Picard <ypicard@edisonscientific.com> ypicard <ypicard@edisonscientific.com>

--- a/packages/lmi/README.md
+++ b/packages/lmi/README.md
@@ -246,7 +246,7 @@ The rate limiter supports two storage backends:
    # Set REDIS_URL environment variable
    import os
 
-   os.environ["REDIS_URL"] = "localhost:6379"
+   os.environ["REDIS_URL"] = "redis://localhost:6379"
 
    from lmi.rate_limiter import GlobalRateLimiter
 

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -30,6 +30,8 @@ CROSSREF_BASE_URL = f"https://{CROSSREF_HOST}"
 
 GLOBAL_RATE_LIMITER_TIMEOUT = float(os.environ.get("RATE_LIMITER_TIMEOUT", "60"))
 
+REDIS_URL = os.environ.get("REDIS_URL")
+
 RATE_LIMITER_REDIS_OP_TIMEOUT = 5.0
 
 MATCH_ALL = None
@@ -102,7 +104,7 @@ class GlobalRateLimiter:
             dict[tuple[str, str | MatchAllInputs], RateLimitItem] | None
         ) = None,
         use_in_memory: bool = False,
-        redis_url: str | None = None,
+        redis_url: str | None = REDIS_URL,
     ):
         """Initialize a GlobalRateLimiter instance.
 
@@ -113,23 +115,15 @@ class GlobalRateLimiter:
                 is available. When False (the default), in-memory storage is still
                 used as a fallback if no Redis URL is provided via `redis_url` or
                 the `REDIS_URL` environment variable.
-            redis_url: Optional Redis URL to use for storage. If not provided, the
-                `REDIS_URL` environment variable will be used. Supports
-                `redis://host:port` (plaintext), `rediss://host:port` (TLS, e.g.
-                AWS ElastiCache with in-transit encryption), and bare `host:port`
-                (treated as plaintext).
+            redis_url: Redis URL for storage, defaulting to the `REDIS_URL` env var
+                (unset uses in-memory). Must include a scheme: `rediss://` (TLS) or
+                `redis://` (plaintext); a scheme-less URL raises.
         """
         self._rate_config = RATE_CONFIG if rate_config is None else rate_config
-        self._redis_url = redis_url or os.environ.get("REDIS_URL")
+        self._redis_url = redis_url
         self._use_in_memory = use_in_memory or not self._redis_url
-        self._redis_tls = (
-            self._redis_url.startswith("rediss://") if self._redis_url else False
-        )
-        # Redis over SSL when possible.
-        self._redis_scheme = "async+rediss" if self._redis_tls else "async+redis"
-        self._redis_bare_url = (
-            self._strip_scheme(self._redis_url) if self._redis_url else ""
-        )
+        if not self._use_in_memory:
+            self._validate_redis_scheme(self._redis_url)
         self._storage: RedisStorage | MemoryStorage | None = None
         self._rate_limiter: MovingWindowRateLimiter | None = None
         self._current_ip: str | None = None
@@ -147,8 +141,15 @@ class GlobalRateLimiter:
         return None
 
     @staticmethod
-    def _strip_scheme(redis_url: str) -> str:
-        return redis_url.removeprefix("rediss://").removeprefix("redis://")
+    def _validate_redis_scheme(redis_url: str | None) -> None:
+        """Require an explicit `redis://` or `rediss://` scheme.
+
+        A scheme-less URL would silently default to plaintext and hang against a
+        TLS-required endpoint (e.g. AWS ElastiCache), so reject it at construction.
+        """
+        if not redis_url or not redis_url.startswith(("redis://", "rediss://")):
+            # Don't echo the URL: a scheme-less value may embed a password.
+            raise ValueError("Redis URL must start with 'redis://' or 'rediss://'.")
 
     async def outbount_ip(self) -> str:
         if self._current_ip is None:
@@ -169,15 +170,14 @@ class GlobalRateLimiter:
         if self._storage is None:
             if self._use_in_memory:
                 self._storage = MemoryStorage()
-                logger.info("Using in-memory rate limiter.")
+                logger.warning("Using in-memory rate limiter.")
             else:
-                conn = f"{self._redis_scheme}://{self._redis_bare_url}"
+                # `async+` tells `limits` to use its asyncio Redis backend.
                 self._storage = RedisStorage(
-                    conn,
+                    f"async+{self._redis_url}",
                     stream_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
                     connect_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
                 )
-                logger.info(f"Connected to redis instance for rate limiting: {conn}")
 
         return self._storage
 
@@ -290,27 +290,13 @@ class GlobalRateLimiter:
         self, cursor_scan_count: int = 100
     ) -> list[tuple[RateLimitItem, tuple[str, str | MatchAllInputs]]]:
         """Returns a list of current RateLimitItems with tuples of namespace and primary key."""
-        # urlparse requires a scheme prefix to extract host/port/password from
-        # bare "host:port" or ":password@host:port" URLs.
-        try:
-            url = f"{self._redis_scheme}://{self._redis_bare_url}"
-            parsed = urlparse(url)
-        except ValueError as exc:
-            raise ValueError(
-                f"Failed to parse host and port from Redis URL {url!r}."
-            ) from exc
-
         if not isinstance(self.storage, RedisStorage):
             raise NotImplementedError(
                 "get_rate_limit_keys only works with RedisStorage."
             )
 
-        client = Redis(
-            host=parsed.hostname,
-            port=parsed.port,
-            password=parsed.password,
-            ssl=self._redis_tls,
-        )
+        assert self._redis_url is not None  # RedisStorage implies a Redis URL
+        client = Redis.from_url(self._redis_url)
 
         try:
             cursor: int | bytes = b"0"

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -4,7 +4,6 @@ import uuid
 from itertools import product
 from typing import Any
 from unittest.mock import AsyncMock, patch
-from urllib.parse import urlparse
 
 import httpx_aiohttp
 import pytest
@@ -401,59 +400,29 @@ async def test_rpm_concurrent_requests(llm_config_w_request_limits: dict[str, An
 
 class TestGlobalRateLimiter:
     @pytest.mark.parametrize(
-        ("redis_url_factory", "expected_redis_kwargs"),
+        "redis_url",
         [
             pytest.param(
-                lambda: "10.58.188.212:6379",
-                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
-                id="plain-host-port",
+                f"redis://:{uuid.uuid4()}@10.58.188.212:6379", id="password-protected"
             ),
-            pytest.param(
-                lambda: f":{uuid.uuid4()}@10.58.188.212:6379",
-                lambda url: {
-                    "host": "10.58.188.212",
-                    "port": 6379,
-                    "password": urlparse(f"redis://{url}").password,
-                    "ssl": False,
-                },
-                id="password-protected",
-            ),
-            pytest.param(
-                lambda: "redis://10.58.188.212:6379",
-                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": False},
-                id="redis-scheme",
-            ),
-            pytest.param(
-                lambda: "rediss://10.58.188.212:6379",
-                {"host": "10.58.188.212", "port": 6379, "password": None, "ssl": True},
-                id="rediss-scheme",
-            ),
+            pytest.param("redis://10.58.188.212:6379", id="redis-scheme"),
+            pytest.param("rediss://10.58.188.212:6379", id="rediss-scheme"),
         ],
     )
     @pytest.mark.asyncio
-    async def test_get_rate_limit_keys_parses_redis_url(
-        self, redis_url_factory, expected_redis_kwargs
-    ) -> None:
-        """Test that get_rate_limit_keys correctly parses both plain and password-protected Redis URLs."""
-        redis_url = redis_url_factory()
-        if callable(expected_redis_kwargs):
-            expected_redis_kwargs = expected_redis_kwargs(redis_url)
+    async def test_get_rate_limit_keys_builds_client_from_url(self, redis_url) -> None:
+        """The schemed URL (incl. TLS via `rediss://`) is passed verbatim to coredis."""
         limiter = GlobalRateLimiter(redis_url=redis_url)
         with patch("lmi.rate_limiter.Redis") as mock_redis_cls:
-            mock_client = mock_redis_cls.return_value
+            mock_client = mock_redis_cls.from_url.return_value
             mock_client.scan = AsyncMock(return_value=(0, []))
             mock_client.quit = AsyncMock()
             await limiter.get_rate_limit_keys()
-            mock_redis_cls.assert_called_once_with(**expected_redis_kwargs)
+            mock_redis_cls.from_url.assert_called_once_with(redis_url)
 
     @pytest.mark.parametrize(
         ("redis_url", "expected_storage_url"),
         [
-            pytest.param(
-                "10.58.188.212:6379",
-                "async+redis://10.58.188.212:6379",
-                id="plain-host-port",
-            ),
             pytest.param(
                 "redis://10.58.188.212:6379",
                 "async+redis://10.58.188.212:6379",
@@ -478,6 +447,23 @@ class TestGlobalRateLimiter:
                 stream_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
                 connect_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
             )
+
+    @pytest.mark.parametrize(
+        "redis_url",
+        [
+            pytest.param("10.58.188.212:6379", id="plain-host-port"),
+            pytest.param(":secret@10.58.188.212:6379", id="scheme-less-with-auth"),
+            pytest.param("http://10.58.188.212:6379", id="wrong-scheme"),
+        ],
+    )
+    def test_scheme_less_redis_url_is_rejected(self, redis_url) -> None:
+        with pytest.raises(ValueError, match="must start with"):
+            GlobalRateLimiter(redis_url=redis_url)
+
+    def test_scheme_less_url_allowed_when_in_memory(self) -> None:
+        # Forcing in-memory storage ignores the Redis URL, so no scheme is required.
+        limiter = GlobalRateLimiter(redis_url="10.58.188.212:6379", use_in_memory=True)
+        assert limiter._use_in_memory
 
     @pytest.mark.asyncio
     async def test_parsing_namespace(self) -> None:


### PR DESCRIPTION
## Why

Rate-limited agents that talk to a TLS-required Redis (for example AWS ElastiCache with in-transit encryption) were failing at startup. The rate limiter decided TLS purely from the URL scheme, but a scheme-less `host:port` was silently treated as plaintext. A plaintext client against a TLS-only endpoint hangs on the handshake, so the failure surfaced much later as a `HELLO timed out` error mid-task rather than at connect time. On plaintext-tolerant Redis (such as GCP Memorystore) the same scheme-less URL happened to work, which is why this stayed hidden.

## What changed

- `GlobalRateLimiter` now validates the Redis URL at construction and rejects a scheme-less URL with a clear error, instead of quietly defaulting to plaintext.
- The scheme (`redis://` vs `rediss://`) is the single source of truth for TLS. Storage goes through `limits` as `async+<url>` and the introspection client uses `coredis.Redis.from_url`, so both derive TLS from the scheme.
- Removed the now-redundant scheme-stripping and manual `ssl=` plumbing.

## Notes

- This is a behavior change for any caller passing a bare `REDIS_URL` (for example existing plaintext GCP setups). They now need an explicit `redis://` prefix. That is intentional: it fails fast at construction rather than silently mid-task.
- Tests cover scheme-less rejection, the schemed URL passing through to coredis (including the TLS case), and a scheme-less URL still being allowed when in-memory storage is forced.