### PR TITLE
feat(lmi): log successful Redis connection for rate limiting [CLD-311]

### DIFF
--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -178,6 +178,8 @@ class GlobalRateLimiter:
                     stream_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
                     connect_timeout=RATE_LIMITER_REDIS_OP_TIMEOUT,
                 )
+                # Don't log the URL: it may embed a password.
+                logger.info("Connected to redis instance for rate limiting.")
 
         return self._storage
 


### PR DESCRIPTION
## Why

When the rate limiter connects to Redis, there's currently no log line confirming it, which makes it harder to tell (from logs alone) whether an agent is using shared Redis limiting or a per-process in-memory fallback. This adds that confirmation back.

The reason it isn't just the obvious one-liner: the previous version logged the full connection string, which can contain an embedded password (`rediss://:token@host:6379`). This logs the fact of the connection without the URL, so no secret ends up in logs.

## What changed

- Log `INFO "Connected to redis instance for rate limiting."` after the Redis storage is created, without interpolating the connection URL.