### PR TITLE
fix(lmi): normalize scheme-less Redis URL instead of rejecting it [CLD-311]

### DIFF
--- a/packages/lmi/src/lmi/constants.py
+++ b/packages/lmi/src/lmi/constants.py
@@ -6,17 +6,8 @@ _URL_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 
 
 def normalize_redis_url(url: str | None) -> str | None:
-    """Prefix a plaintext `redis://` scheme when the URL has no scheme.
-
-    Surrounding whitespace (e.g. a trailing newline from a secret file) is
-    stripped first; an empty or whitespace-only value normalizes to `None`.
-    """
-    if url is None:
-        return None
-    url = url.strip()
-    if not url:
-        return None
-    if not _URL_SCHEME_RE.match(url):
+    """Prefix a plaintext `redis://` scheme when the URL has no scheme."""
+    if url and not _URL_SCHEME_RE.match(url):
         return f"redis://{url}"
     return url
 

--- a/packages/lmi/src/lmi/constants.py
+++ b/packages/lmi/src/lmi/constants.py
@@ -6,8 +6,17 @@ _URL_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 
 
 def normalize_redis_url(url: str | None) -> str | None:
-    """Prefix a plaintext `redis://` scheme when the URL has no scheme."""
-    if url and not _URL_SCHEME_RE.match(url):
+    """Prefix a plaintext `redis://` scheme when the URL has no scheme.
+
+    Surrounding whitespace (e.g. a trailing newline from a secret file) is
+    stripped first; an empty or whitespace-only value normalizes to `None`.
+    """
+    if url is None:
+        return None
+    url = url.strip()
+    if not url:
+        return None
+    if not _URL_SCHEME_RE.match(url):
         return f"redis://{url}"
     return url
 

--- a/packages/lmi/src/lmi/constants.py
+++ b/packages/lmi/src/lmi/constants.py
@@ -1,10 +1,13 @@
 import os
+import re
 from sys import version_info
+
+_URL_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 
 
 def normalize_redis_url(url: str | None) -> str | None:
-    """Ensure a Redis URL carries an explicit scheme."""
-    if url and not url.startswith(("redis://", "rediss://")):
+    """Prefix a plaintext `redis://` scheme when the URL has no scheme."""
+    if url and not _URL_SCHEME_RE.match(url):
         return f"redis://{url}"
     return url
 

--- a/packages/lmi/src/lmi/constants.py
+++ b/packages/lmi/src/lmi/constants.py
@@ -1,4 +1,15 @@
+import os
 from sys import version_info
+
+
+def normalize_redis_url(url: str | None) -> str | None:
+    """Ensure a Redis URL carries an explicit scheme."""
+    if url and "://" not in url:
+        return f"redis://{url}"
+    return url
+
+
+REDIS_URL: str | None = normalize_redis_url(os.environ.get("REDIS_URL"))
 
 # Estimate from OpenAI's FAQ
 # https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them

--- a/packages/lmi/src/lmi/constants.py
+++ b/packages/lmi/src/lmi/constants.py
@@ -4,7 +4,7 @@ from sys import version_info
 
 def normalize_redis_url(url: str | None) -> str | None:
     """Ensure a Redis URL carries an explicit scheme."""
-    if url and "://" not in url:
+    if url and not url.startswith(("redis://", "rediss://")):
         return f"redis://{url}"
     return url
 

--- a/packages/lmi/src/lmi/rate_limiter.py
+++ b/packages/lmi/src/lmi/rate_limiter.py
@@ -18,6 +18,8 @@ from limits import (
 from limits.aio.storage import MemoryStorage, RedisStorage
 from limits.aio.strategies import MovingWindowRateLimiter
 
+from lmi.constants import REDIS_URL, normalize_redis_url
+
 logger = logging.getLogger(__name__)
 
 
@@ -29,8 +31,6 @@ CROSSREF_HOST = "api.crossref.org"
 CROSSREF_BASE_URL = f"https://{CROSSREF_HOST}"
 
 GLOBAL_RATE_LIMITER_TIMEOUT = float(os.environ.get("RATE_LIMITER_TIMEOUT", "60"))
-
-REDIS_URL = os.environ.get("REDIS_URL")
 
 RATE_LIMITER_REDIS_OP_TIMEOUT = 5.0
 
@@ -116,14 +116,12 @@ class GlobalRateLimiter:
                 used as a fallback if no Redis URL is provided via `redis_url` or
                 the `REDIS_URL` environment variable.
             redis_url: Redis URL for storage, defaulting to the `REDIS_URL` env var
-                (unset uses in-memory). Must include a scheme: `rediss://` (TLS) or
-                `redis://` (plaintext); a scheme-less URL raises.
+                (unset uses in-memory). A scheme-less URL is normalized to a
+                plaintext `redis://` URL; pass `rediss://` explicitly for TLS.
         """
         self._rate_config = RATE_CONFIG if rate_config is None else rate_config
-        self._redis_url = redis_url
+        self._redis_url = normalize_redis_url(redis_url)
         self._use_in_memory = use_in_memory or not self._redis_url
-        if not self._use_in_memory:
-            self._validate_redis_scheme(self._redis_url)
         self._storage: RedisStorage | MemoryStorage | None = None
         self._rate_limiter: MovingWindowRateLimiter | None = None
         self._current_ip: str | None = None
@@ -139,17 +137,6 @@ class GlobalRateLimiter:
         except aiohttp.ClientError:
             logger.warning(f"Error occurred while connecting to {url}.", exc_info=True)
         return None
-
-    @staticmethod
-    def _validate_redis_scheme(redis_url: str | None) -> None:
-        """Require an explicit `redis://` or `rediss://` scheme.
-
-        A scheme-less URL would silently default to plaintext and hang against a
-        TLS-required endpoint (e.g. AWS ElastiCache), so reject it at construction.
-        """
-        if not redis_url or not redis_url.startswith(("redis://", "rediss://")):
-            # Don't echo the URL: a scheme-less value may embed a password.
-            raise ValueError("Redis URL must start with 'redis://' or 'rediss://'.")
 
     async def outbount_ip(self) -> str:
         if self._current_ip is None:

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -462,6 +462,11 @@ class TestGlobalRateLimiter:
                 id="scheme-less-with-auth",
             ),
             pytest.param(
+                ":pa://ss@10.58.188.212:6379",
+                "redis://:pa://ss@10.58.188.212:6379",
+                id="scheme-less-with-uri-chars-in-password",
+            ),
+            pytest.param(
                 "redis://10.58.188.212:6379",
                 "redis://10.58.188.212:6379",
                 id="redis-scheme-unchanged",

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -473,9 +473,7 @@ class TestGlobalRateLimiter:
             ),
         ],
     )
-    def test_scheme_less_redis_url_is_normalized(
-        self, redis_url, expected_url
-    ) -> None:
+    def test_scheme_less_redis_url_is_normalized(self, redis_url, expected_url) -> None:
         # A scheme-less URL defaults to plaintext `redis://`; an explicit scheme
         # (incl. `rediss://` for TLS) is preserved.
         limiter = GlobalRateLimiter(redis_url=redis_url)

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -481,23 +481,11 @@ class TestGlobalRateLimiter:
                 "unix:///var/run/redis.sock",
                 id="other-scheme-unchanged",
             ),
-            pytest.param(
-                "redis://10.58.188.212:6379\n",
-                "redis://10.58.188.212:6379",
-                id="trailing-newline-stripped",
-            ),
-            pytest.param(
-                "  10.58.188.212:6379  ",
-                "redis://10.58.188.212:6379",
-                id="surrounding-whitespace-stripped",
-            ),
-            pytest.param("   ", None, id="whitespace-only-is-none"),
         ],
     )
     def test_scheme_less_redis_url_is_normalized(self, redis_url, expected_url) -> None:
         # A scheme-less URL defaults to plaintext `redis://`; an explicit scheme
-        # (incl. `rediss://` for TLS) is preserved. Surrounding whitespace is
-        # stripped, and a whitespace-only value falls back to in-memory (None).
+        # (incl. `rediss://` for TLS) is preserved.
         limiter = GlobalRateLimiter(redis_url=redis_url)
         assert limiter._redis_url == expected_url
 

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -476,6 +476,11 @@ class TestGlobalRateLimiter:
                 "rediss://10.58.188.212:6379",
                 id="rediss-scheme-unchanged",
             ),
+            pytest.param(
+                "unix:///var/run/redis.sock",
+                "unix:///var/run/redis.sock",
+                id="other-scheme-unchanged",
+            ),
         ],
     )
     def test_scheme_less_redis_url_is_normalized(self, redis_url, expected_url) -> None:

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -481,11 +481,23 @@ class TestGlobalRateLimiter:
                 "unix:///var/run/redis.sock",
                 id="other-scheme-unchanged",
             ),
+            pytest.param(
+                "redis://10.58.188.212:6379\n",
+                "redis://10.58.188.212:6379",
+                id="trailing-newline-stripped",
+            ),
+            pytest.param(
+                "  10.58.188.212:6379  ",
+                "redis://10.58.188.212:6379",
+                id="surrounding-whitespace-stripped",
+            ),
+            pytest.param("   ", None, id="whitespace-only-is-none"),
         ],
     )
     def test_scheme_less_redis_url_is_normalized(self, redis_url, expected_url) -> None:
         # A scheme-less URL defaults to plaintext `redis://`; an explicit scheme
-        # (incl. `rediss://` for TLS) is preserved.
+        # (incl. `rediss://` for TLS) is preserved. Surrounding whitespace is
+        # stripped, and a whitespace-only value falls back to in-memory (None).
         limiter = GlobalRateLimiter(redis_url=redis_url)
         assert limiter._redis_url == expected_url
 

--- a/packages/lmi/tests/test_rate_limiter.py
+++ b/packages/lmi/tests/test_rate_limiter.py
@@ -449,19 +449,40 @@ class TestGlobalRateLimiter:
             )
 
     @pytest.mark.parametrize(
-        "redis_url",
+        ("redis_url", "expected_url"),
         [
-            pytest.param("10.58.188.212:6379", id="plain-host-port"),
-            pytest.param(":secret@10.58.188.212:6379", id="scheme-less-with-auth"),
-            pytest.param("http://10.58.188.212:6379", id="wrong-scheme"),
+            pytest.param(
+                "10.58.188.212:6379",
+                "redis://10.58.188.212:6379",
+                id="plain-host-port",
+            ),
+            pytest.param(
+                ":secret@10.58.188.212:6379",
+                "redis://:secret@10.58.188.212:6379",
+                id="scheme-less-with-auth",
+            ),
+            pytest.param(
+                "redis://10.58.188.212:6379",
+                "redis://10.58.188.212:6379",
+                id="redis-scheme-unchanged",
+            ),
+            pytest.param(
+                "rediss://10.58.188.212:6379",
+                "rediss://10.58.188.212:6379",
+                id="rediss-scheme-unchanged",
+            ),
         ],
     )
-    def test_scheme_less_redis_url_is_rejected(self, redis_url) -> None:
-        with pytest.raises(ValueError, match="must start with"):
-            GlobalRateLimiter(redis_url=redis_url)
+    def test_scheme_less_redis_url_is_normalized(
+        self, redis_url, expected_url
+    ) -> None:
+        # A scheme-less URL defaults to plaintext `redis://`; an explicit scheme
+        # (incl. `rediss://` for TLS) is preserved.
+        limiter = GlobalRateLimiter(redis_url=redis_url)
+        assert limiter._redis_url == expected_url
 
     def test_scheme_less_url_allowed_when_in_memory(self) -> None:
-        # Forcing in-memory storage ignores the Redis URL, so no scheme is required.
+        # Forcing in-memory storage ignores the Redis URL entirely.
         limiter = GlobalRateLimiter(redis_url="10.58.188.212:6379", use_in_memory=True)
         assert limiter._use_in_memory
 


### PR DESCRIPTION
Auto-populate the schema when absent from REDIS_URL.