### PR TITLE
Translate reasoning_effort into OpenRouter's request body at dispatch

### DIFF
--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -899,9 +899,9 @@ def _modify_call_kwargs(call_kwargs: dict[str, Any]) -> dict[str, Any]:
     rejects `reasoning_effort` for any model it has not mapped as
     reasoning-capable, so for OpenRouter models we move a top-level
     `reasoning_effort` into `extra_body.reasoning.effort`, deep-merged into any
-    existing `extra_body` (e.g. a caller-set `provider.only`). Other providers and
-    calls without `reasoning_effort` are returned unchanged. Returns a new dict
-    rather than mutating the input.
+    existing `extra_body` (e.g. a caller-set `provider.only`). Never mutates the
+    input: other providers and calls without `reasoning_effort` get the same dict
+    back unchanged, and the OpenRouter path returns a new dict.
     """
     if (
         not str(call_kwargs.get("model", "")).startswith("openrouter/")
@@ -1484,6 +1484,7 @@ class LiteLLMModel(LLMModel):
         }
         if previous_response_id is not None:
             call_kwargs["previous_response_id"] = previous_response_id
+        call_kwargs = _modify_call_kwargs(call_kwargs)
 
         try:
             response = await track_costs(litellm.aresponses)(**call_kwargs)
@@ -1570,6 +1571,7 @@ class LiteLLMModel(LLMModel):
         }
         if previous_response_id is not None:
             call_kwargs["previous_response_id"] = previous_response_id
+        call_kwargs = _modify_call_kwargs(call_kwargs)
 
         try:
             stream = await track_costs_iter(litellm.aresponses)(**call_kwargs)

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -903,11 +903,12 @@ def _modify_call_kwargs(call_kwargs: dict[str, Any]) -> dict[str, Any]:
     calls without `reasoning_effort` are returned unchanged. Returns a new dict
     rather than mutating the input.
     """
-    if not str(call_kwargs.get("model", "")).startswith("openrouter/"):
+    if (
+        not str(call_kwargs.get("model", "")).startswith("openrouter/")
+        or "reasoning_effort" not in call_kwargs
+    ):
         return call_kwargs
-    if "reasoning_effort" not in call_kwargs:
-        return call_kwargs
-    call_kwargs = dict(call_kwargs)
+    call_kwargs = call_kwargs.copy()  # copy so we don't mutate the original dict
     effort = call_kwargs.pop("reasoning_effort")
     extra_body = dict(call_kwargs.get("extra_body") or {})
     extra_body["reasoning"] = {**extra_body.get("reasoning", {}), "effort": effort}

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -890,6 +890,31 @@ def _without_tool_only_kwargs(call_kwargs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _modify_call_kwargs(call_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Reshape params into a provider's request body before dispatch.
+
+    OpenRouter takes reasoning controls as a `reasoning: {"effort": ...}` object
+    in the request body (`extra_body`), not the top-level `reasoning_effort` that
+    OpenAI and Anthropic accept. LiteLLM does not convert this for OpenRouter and
+    rejects `reasoning_effort` for any model it has not mapped as
+    reasoning-capable, so for OpenRouter models we move a top-level
+    `reasoning_effort` into `extra_body.reasoning.effort`, deep-merged into any
+    existing `extra_body` (e.g. a caller-set `provider.only`). Other providers and
+    calls without `reasoning_effort` are returned unchanged. Returns a new dict
+    rather than mutating the input.
+    """
+    if not str(call_kwargs.get("model", "")).startswith("openrouter/"):
+        return call_kwargs
+    if "reasoning_effort" not in call_kwargs:
+        return call_kwargs
+    call_kwargs = dict(call_kwargs)
+    effort = call_kwargs.pop("reasoning_effort")
+    extra_body = dict(call_kwargs.get("extra_body") or {})
+    extra_body["reasoning"] = {**extra_body.get("reasoning", {}), "effort": effort}
+    call_kwargs["extra_body"] = extra_body
+    return call_kwargs
+
+
 def default_tool_parser(
     choice: litellm.utils.Choices, tools: list[dict] | None
 ) -> Message | ToolRequestMessage:
@@ -1213,6 +1238,7 @@ class LiteLLMModel(LLMModel):
 
         call_kwargs = {**spec.to_litellm_kwargs(), **kwargs, "messages": prompts}
         call_kwargs = _without_tool_only_kwargs(call_kwargs)
+        call_kwargs = _modify_call_kwargs(call_kwargs)
         try:
             completions = await track_costs(litellm.acompletion)(**call_kwargs)
         except Exception:
@@ -1328,7 +1354,7 @@ class LiteLLMModel(LLMModel):
     # the order should be first request and then rate(token)
     @request_limited
     @rate_limited
-    async def acompletion_iter(  # noqa: C901
+    async def acompletion_iter(  # noqa: C901, PLR0915
         self, messages: list[Message], *, spec: ModelSpec | None = None, **kwargs
     ) -> AsyncIterable[LLMResult]:
         if spec is None:
@@ -1353,6 +1379,7 @@ class LiteLLMModel(LLMModel):
             "stream_options": stream_options,
         }
         call_kwargs = _without_tool_only_kwargs(call_kwargs)
+        call_kwargs = _modify_call_kwargs(call_kwargs)
         try:
             stream_completions = await track_costs_iter(litellm.acompletion)(
                 **call_kwargs

--- a/packages/lmi/tests/test_llms.py
+++ b/packages/lmi/tests/test_llms.py
@@ -28,6 +28,7 @@ from lmi.llms import (
     _convert_tool_response_for_responses,
     _convert_tools_for_responses,
     _extract_previous_response_id,
+    _modify_call_kwargs,
     _parse_responses_output,
     estimate_message_tokens,
     validate_json_completion,
@@ -1553,3 +1554,37 @@ class TestResponsesAPIIntegration:
 
         assert len(results) == 1
         assert results[0].response_id is None
+
+
+class TestModifyCallKwargs:
+    """`_modify_call_kwargs` reshapes reasoning into OpenRouter's request body."""
+
+    GLM: ClassVar[str] = "openrouter/z-ai/glm-5.2"
+
+    def test_reasoning_effort_moved_into_extra_body(self):
+        out = _modify_call_kwargs({"model": self.GLM, "reasoning_effort": "high"})
+        assert "reasoning_effort" not in out
+        assert out["extra_body"] == {"reasoning": {"effort": "high"}}
+
+    def test_merges_into_existing_extra_body(self):
+        # A caller-set provider.only (e.g. from ModelSpec.extra_params) is preserved.
+        out = _modify_call_kwargs({
+            "model": self.GLM,
+            "reasoning_effort": "medium",
+            "extra_body": {"provider": {"only": ["fireworks"]}},
+        })
+        assert out["extra_body"] == {
+            "provider": {"only": ["fireworks"]},
+            "reasoning": {"effort": "medium"},
+        }
+
+    def test_non_openrouter_model_untouched(self):
+        call_kwargs = {"model": "anthropic/claude-opus-4-6", "reasoning_effort": "high"}
+        assert _modify_call_kwargs(call_kwargs) == call_kwargs
+
+    def test_openrouter_without_reasoning_effort_is_noop(self):
+        call_kwargs = {
+            "model": self.GLM,
+            "extra_body": {"provider": {"only": ["wandb"]}},
+        }
+        assert _modify_call_kwargs(call_kwargs) == call_kwargs

--- a/packages/lmi/tests/test_llms.py
+++ b/packages/lmi/tests/test_llms.py
@@ -1561,12 +1561,12 @@ class TestModifyCallKwargs:
 
     GLM: ClassVar[str] = "openrouter/z-ai/glm-5.2"
 
-    def test_reasoning_effort_moved_into_extra_body(self):
+    def test_reasoning_effort_moved_into_extra_body(self) -> None:
         out = _modify_call_kwargs({"model": self.GLM, "reasoning_effort": "high"})
         assert "reasoning_effort" not in out
         assert out["extra_body"] == {"reasoning": {"effort": "high"}}
 
-    def test_merges_into_existing_extra_body(self):
+    def test_merges_into_existing_extra_body(self) -> None:
         # A caller-set provider.only (e.g. from ModelSpec.extra_params) is preserved.
         out = _modify_call_kwargs({
             "model": self.GLM,
@@ -1578,18 +1578,18 @@ class TestModifyCallKwargs:
             "reasoning": {"effort": "medium"},
         }
 
-    def test_non_openrouter_model_untouched(self):
+    def test_non_openrouter_model_untouched(self) -> None:
         call_kwargs = {"model": "anthropic/claude-opus-4-6", "reasoning_effort": "high"}
         assert _modify_call_kwargs(call_kwargs) == call_kwargs
 
-    def test_openrouter_without_reasoning_effort_is_noop(self):
+    def test_openrouter_without_reasoning_effort_is_noop(self) -> None:
         call_kwargs = {
             "model": self.GLM,
             "extra_body": {"provider": {"only": ["wandb"]}},
         }
         assert _modify_call_kwargs(call_kwargs) == call_kwargs
 
-    def test_stateless_does_not_mutate_input_or_shared_extra_body(self):
+    def test_stateless_does_not_mutate_input_or_shared_extra_body(self) -> None:
         # A fallback chain reuses call_kwargs and a ModelSpec's extra_body for the
         # next provider, so neither may be mutated in place.
         shared_extra_body = {"provider": {"only": ["fireworks"]}}

--- a/packages/lmi/tests/test_llms.py
+++ b/packages/lmi/tests/test_llms.py
@@ -1588,3 +1588,21 @@ class TestModifyCallKwargs:
             "extra_body": {"provider": {"only": ["wandb"]}},
         }
         assert _modify_call_kwargs(call_kwargs) == call_kwargs
+
+    def test_stateless_does_not_mutate_input_or_shared_extra_body(self):
+        # A fallback chain reuses call_kwargs and a ModelSpec's extra_body for the
+        # next provider, so neither may be mutated in place.
+        shared_extra_body = {"provider": {"only": ["fireworks"]}}
+        call_kwargs = {
+            "model": self.GLM,
+            "reasoning_effort": "high",
+            "extra_body": shared_extra_body,
+        }
+        out = _modify_call_kwargs(call_kwargs)
+        # input untouched
+        assert call_kwargs["reasoning_effort"] == "high"
+        assert call_kwargs["extra_body"] is shared_extra_body
+        assert shared_extra_body == {"provider": {"only": ["fireworks"]}}
+        # transformation is only on the returned copy
+        assert "reasoning_effort" not in out
+        assert out["extra_body"]["reasoning"] == {"effort": "high"}


### PR DESCRIPTION
Openrouter decided to be all special and use the parameter `reasoning` for reasoning effort, in contrast to what the frontier apis accept, which is `reasoning_effort`. So we have to change it when the model string starts with openrouter.