### PR TITLE
Require closable async iterators

### DIFF
--- a/packages/lmi/src/lmi/cost_tracker.py
+++ b/packages/lmi/src/lmi/cost_tracker.py
@@ -186,6 +186,10 @@ class TrackedStreamWrapper:
                 _requested_model_ctx.reset(token)
         return response
 
+    async def aclose(self) -> None:
+        """Close the wrapped provider stream."""
+        await self.stream.aclose()
+
 
 def track_costs_iter(
     func: Callable[TParams, Awaitable[litellm.CustomStreamWrapper]],

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -377,27 +377,27 @@ class CommonLLMNames(StrEnum):
 
 
 async def _commit_stream(
-    gen: ClosableAsyncIterator[LLMResult],
+    stream: ClosableAsyncIterator[LLMResult],
 ) -> ClosableAsyncIterator[LLMResult]:
-    """Prime `gen` and return a generator that replays its first result.
+    """Advance `stream` to its first result and return an iterator that replays it.
 
     Errors raised while fetching the first result propagate before this function
     returns. Later results and errors pass through unchanged. If the consumer
-    cancels or closes the returned generator early, `gen` is also closed so the
+    cancels or closes the returned iterator early, `stream` is also closed so the
     provider stream can release its resources.
     """
     try:
-        first = await anext(gen)
+        first = await anext(stream)
     except StopAsyncIteration as exc:
         raise RuntimeError("Stream closed before producing any output.") from exc
 
     async def replay() -> ClosableAsyncIterator[LLMResult]:
         try:
             yield first
-            async for item in gen:
+            async for item in stream:
                 yield item
         finally:
-            await gen.aclose()
+            await stream.aclose()
 
     return replay()
 

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -20,7 +20,6 @@ import json
 import logging
 from abc import ABC
 from collections.abc import (
-    AsyncGenerator,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -379,7 +378,7 @@ class CommonLLMNames(StrEnum):
 
 async def _commit_stream(
     gen: ClosableAsyncIterator[LLMResult],
-) -> AsyncGenerator[LLMResult]:
+) -> ClosableAsyncIterator[LLMResult]:
     """Prime `gen` and return a generator that replays its first result.
 
     Errors raised while fetching the first result propagate before this function
@@ -392,7 +391,7 @@ async def _commit_stream(
     except StopAsyncIteration as exc:
         raise RuntimeError("Stream closed before producing any output.") from exc
 
-    async def replay() -> AsyncGenerator[LLMResult]:
+    async def replay() -> ClosableAsyncIterator[LLMResult]:
         try:
             yield first
             async for item in gen:
@@ -791,8 +790,8 @@ def rate_limited(
 
 @overload
 def rate_limited(
-    func: Callable[P, AsyncGenerator[LLMResult]],
-) -> Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]]: ...
+    func: Callable[P, ClosableAsyncIterator[LLMResult]],
+) -> Callable[P, Coroutine[Any, Any, ClosableAsyncIterator[LLMResult]]]: ...
 
 
 def rate_limited(func):
@@ -818,7 +817,7 @@ def rate_limited(func):
         # portion before yielding
         if isasyncgenfunction(func):
 
-            async def rate_limited_generator() -> AsyncGenerator[LLMResult]:
+            async def rate_limited_generator() -> ClosableAsyncIterator[LLMResult]:
                 source = func(self, *args, **kwargs)
                 try:
                     async for item in source:
@@ -851,8 +850,8 @@ def request_limited(
 
 @overload
 def request_limited(
-    func: Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]],
-) -> Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]]: ...
+    func: Callable[P, Coroutine[Any, Any, ClosableAsyncIterator[LLMResult]]],
+) -> Callable[P, Coroutine[Any, Any, ClosableAsyncIterator[LLMResult]]]: ...
 
 
 def request_limited(func):
@@ -869,7 +868,7 @@ def request_limited(func):
 
         if isasyncgenfunction(func):
 
-            async def request_limited_generator() -> AsyncGenerator[LLMResult]:
+            async def request_limited_generator() -> ClosableAsyncIterator[LLMResult]:
                 first_item = True
                 source = func(self, *args, **kwargs)
                 try:
@@ -1156,7 +1155,7 @@ class LiteLLMModel(LLMModel):
         messages: list[Message],
         streaming: bool = False,
         **chat_kwargs,
-    ) -> list[LLMResult] | AsyncGenerator[LLMResult]:
+    ) -> list[LLMResult] | ClosableAsyncIterator[LLMResult]:
         """Dispatch one request to `spec`, choosing Chat vs Responses per `spec.responses_api`.
 
         Non-streaming paths return a list of `LLMResult`s. Streaming paths
@@ -1392,7 +1391,7 @@ class LiteLLMModel(LLMModel):
     @rate_limited
     async def acompletion_iter(  # noqa: C901, PLR0915
         self, messages: list[Message], *, spec: ModelSpec | None = None, **kwargs
-    ) -> AsyncGenerator[LLMResult]:
+    ) -> ClosableAsyncIterator[LLMResult]:
         if spec is None:
             spec = cast("LLMConfig", self.llm_config).models[0]
         # cast is necessary for LiteLLM typing bug: https://github.com/BerriAI/litellm/issues/7641
@@ -1589,7 +1588,7 @@ class LiteLLMModel(LLMModel):
         *,
         spec: ModelSpec | None = None,
         **kwargs,
-    ) -> AsyncGenerator[LLMResult]:
+    ) -> ClosableAsyncIterator[LLMResult]:
         """Stream results from the Responses API."""
         if spec is None:
             spec = cast("LLMConfig", self.llm_config).models[0]

--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "ClosableAsyncIterator",
     "CommonLLMNames",
     "LLMModel",
     "LiteLLMModel",
@@ -19,7 +20,8 @@ import json
 import logging
 from abc import ABC
 from collections.abc import (
-    AsyncIterable,
+    AsyncGenerator,
+    AsyncIterator,
     Awaitable,
     Callable,
     Coroutine,
@@ -29,7 +31,16 @@ from collections.abc import (
 )
 from enum import StrEnum
 from inspect import isasyncgenfunction, isawaitable, signature
-from typing import Any, ClassVar, ParamSpec, TypeAlias, cast, overload
+from typing import (
+    Any,
+    ClassVar,
+    ParamSpec,
+    Protocol,
+    TypeAlias,
+    TypeVar,
+    cast,
+    overload,
+)
 
 import litellm
 from aviary.core import (
@@ -94,6 +105,16 @@ from . import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class ClosableAsyncIterator(AsyncIterator[T_co], Protocol):
+    """An async iterator that supports explicit resource cleanup."""
+
+    async def aclose(self) -> None:
+        """Close the iterator and release its resources."""
 
 
 def _convert_content_block_for_responses(block: dict[str, Any]) -> dict[str, Any]:
@@ -356,24 +377,28 @@ class CommonLLMNames(StrEnum):
     )
 
 
-async def _commit_stream(gen: AsyncIterable[LLMResult]) -> AsyncIterable[LLMResult]:
-    """Advance `gen` to its first yield and return an iterator that replays it.
+async def _commit_stream(
+    gen: ClosableAsyncIterator[LLMResult],
+) -> AsyncGenerator[LLMResult]:
+    """Prime `gen` and return a generator that replays its first result.
 
-    Exceptions raised before the first yield propagate to the caller. Once the
-    first chunk has been produced the returned iterator yields it and then
-    forwards the rest of `gen` verbatim; any mid-stream error surfaces
-    unmodified to the consumer.
+    Errors raised while fetching the first result propagate before this function
+    returns. Later results and errors pass through unchanged. If the consumer
+    cancels or closes the returned generator early, `gen` is also closed so the
+    provider stream can release its resources.
     """
-    iterator = aiter(gen)
     try:
-        first = await anext(iterator)
+        first = await anext(gen)
     except StopAsyncIteration as exc:
         raise RuntimeError("Stream closed before producing any output.") from exc
 
-    async def replay() -> AsyncIterable[LLMResult]:
-        yield first
-        async for item in iterator:
-            yield item
+    async def replay() -> AsyncGenerator[LLMResult]:
+        try:
+            yield first
+            async for item in gen:
+                yield item
+        finally:
+            await gen.aclose()
 
     return replay()
 
@@ -514,10 +539,12 @@ class LLMModel(ABC, BaseModel):
 
     async def acompletion_iter(
         self, messages: list[Message], *, spec: ModelSpec | None = None, **kwargs
-    ) -> AsyncIterable[LLMResult]:
+    ) -> ClosableAsyncIterator[LLMResult]:
         """Stream one completion from the model given by `spec`.
 
-        See `acompletion` for the `spec` contract.
+        The returned iterator must support `aclose()` so callers can release
+        provider resources when they stop before exhausting the stream. See
+        `acompletion` for the `spec` contract.
         """
         raise NotImplementedError
 
@@ -764,8 +791,8 @@ def rate_limited(
 
 @overload
 def rate_limited(
-    func: Callable[P, AsyncIterable[LLMResult]],
-) -> Callable[P, Coroutine[Any, Any, AsyncIterable[LLMResult]]]: ...
+    func: Callable[P, AsyncGenerator[LLMResult]],
+) -> Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]]: ...
 
 
 def rate_limited(func):
@@ -791,15 +818,19 @@ def rate_limited(func):
         # portion before yielding
         if isasyncgenfunction(func):
 
-            async def rate_limited_generator() -> AsyncIterable[LLMResult]:
-                async for item in func(self, *args, **kwargs):
-                    token_count = 0
-                    if isinstance(item, LLMResult):
-                        token_count = int(
-                            len(item.text or "") / CHARACTERS_PER_TOKEN_ASSUMPTION
-                        )
-                    await self.check_rate_limit(token_count)
-                    yield item
+            async def rate_limited_generator() -> AsyncGenerator[LLMResult]:
+                source = func(self, *args, **kwargs)
+                try:
+                    async for item in source:
+                        token_count = 0
+                        if isinstance(item, LLMResult):
+                            token_count = int(
+                                len(item.text or "") / CHARACTERS_PER_TOKEN_ASSUMPTION
+                            )
+                        await self.check_rate_limit(token_count)
+                        yield item
+                finally:
+                    await source.aclose()
 
             return rate_limited_generator()
 
@@ -820,8 +851,8 @@ def request_limited(
 
 @overload
 def request_limited(
-    func: Callable[P, Coroutine[Any, Any, AsyncIterable[LLMResult]]],
-) -> Callable[P, Coroutine[Any, Any, AsyncIterable[LLMResult]]]: ...
+    func: Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]],
+) -> Callable[P, Coroutine[Any, Any, AsyncGenerator[LLMResult]]]: ...
 
 
 def request_limited(func):
@@ -838,15 +869,19 @@ def request_limited(func):
 
         if isasyncgenfunction(func):
 
-            async def request_limited_generator() -> AsyncIterable[LLMResult]:
+            async def request_limited_generator() -> AsyncGenerator[LLMResult]:
                 first_item = True
-                async for item in func(self, *args, **kwargs):
-                    # Skip rate limit check for first item since we already checked at generator start
-                    if not first_item:
-                        await self.check_request_limit()
-                    else:
-                        first_item = False
-                    yield item
+                source = func(self, *args, **kwargs)
+                try:
+                    async for item in source:
+                        # Skip rate limit check for first item since we already checked at generator start
+                        if not first_item:
+                            await self.check_request_limit()
+                        else:
+                            first_item = False
+                        yield item
+                finally:
+                    await source.aclose()
 
             return request_limited_generator()
         return await func(self, *args, **kwargs)
@@ -1121,11 +1156,11 @@ class LiteLLMModel(LLMModel):
         messages: list[Message],
         streaming: bool = False,
         **chat_kwargs,
-    ) -> list[LLMResult] | AsyncIterable[LLMResult]:
+    ) -> list[LLMResult] | AsyncGenerator[LLMResult]:
         """Dispatch one request to `spec`, choosing Chat vs Responses per `spec.responses_api`.
 
         Non-streaming paths return a list of `LLMResult`s. Streaming paths
-        return an async iterator that has already produced its first chunk;
+        return an async generator that has already produced its first chunk;
         errors before the first chunk (stream-open failure, an immediate
         refusal) surface as exceptions from this coroutine, while mid-stream
         errors propagate unmodified when the caller iterates the result.
@@ -1357,7 +1392,7 @@ class LiteLLMModel(LLMModel):
     @rate_limited
     async def acompletion_iter(  # noqa: C901, PLR0915
         self, messages: list[Message], *, spec: ModelSpec | None = None, **kwargs
-    ) -> AsyncIterable[LLMResult]:
+    ) -> AsyncGenerator[LLMResult]:
         if spec is None:
             spec = cast("LLMConfig", self.llm_config).models[0]
         # cast is necessary for LiteLLM typing bug: https://github.com/BerriAI/litellm/issues/7641
@@ -1554,7 +1589,7 @@ class LiteLLMModel(LLMModel):
         *,
         spec: ModelSpec | None = None,
         **kwargs,
-    ) -> AsyncIterable[LLMResult]:
+    ) -> AsyncGenerator[LLMResult]:
         """Stream results from the Responses API."""
         if spec is None:
             spec = cast("LLMConfig", self.llm_config).models[0]

--- a/packages/lmi/tests/test_cost_tracking.py
+++ b/packages/lmi/tests/test_cost_tracking.py
@@ -41,6 +41,17 @@ def assert_costs_increased():
     assert GLOBAL_COST_TRACKER.lifetime_cost_usd > initial_cost
 
 
+@pytest.mark.asyncio
+async def test_tracked_stream_close_closes_wrapped_stream() -> None:
+    wrapped_stream = MagicMock()
+    wrapped_stream.aclose = AsyncMock()
+    stream = TrackedStreamWrapper(wrapped_stream)
+
+    await stream.aclose()
+
+    wrapped_stream.aclose.assert_awaited_once_with()
+
+
 class TestLiteLLMEmbeddingCosts:
     @pytest.mark.asyncio
     async def test_embed_documents(self):

--- a/packages/lmi/tests/test_dispatch.py
+++ b/packages/lmi/tests/test_dispatch.py
@@ -8,7 +8,7 @@ network access. Unit-level tests exercise `_run_with_fallbacks` and
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -188,7 +188,7 @@ class TestRunWithFallbacks:
 class TestCommitStream:
     @pytest.mark.asyncio
     async def test_replays_all_chunks(self) -> None:
-        async def gen() -> AsyncIterator[LLMResult]:  # noqa: RUF029
+        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
             for chunk in ("a", "b", "c"):
                 yield _chunk(chunk)
 
@@ -198,7 +198,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_pre_first_chunk_error_propagates(self) -> None:
-        async def gen() -> AsyncIterator[LLMResult]:  # noqa: RUF029
+        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
             raise litellm.RateLimitError(
                 message="pre-first-chunk", model=PRIMARY, llm_provider="openai"
             )
@@ -209,7 +209,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_empty_stream_raises_runtime_error(self) -> None:
-        async def gen() -> AsyncIterator[LLMResult]:  # noqa: RUF029
+        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
             return
             yield _chunk("unreachable")  # type: ignore[unreachable]  # pragma: no cover
 
@@ -218,7 +218,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_mid_stream_error_surfaces_unmodified(self) -> None:
-        async def gen() -> AsyncIterator[LLMResult]:  # noqa: RUF029
+        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
             yield _chunk("a")
             raise litellm.APIConnectionError(
                 message="mid-stream", model=PRIMARY, llm_provider="openai"
@@ -231,6 +231,50 @@ class TestCommitStream:
         with pytest.raises(litellm.APIConnectionError):
             async for _ in committed:
                 pass
+
+    @pytest.mark.asyncio
+    async def test_closing_committed_stream_closes_source(self) -> None:
+        source_closed = False
+
+        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+            nonlocal source_closed
+            try:
+                yield _chunk("a")
+                yield _chunk("b")
+            finally:
+                source_closed = True
+
+        committed = await _commit_stream(gen())
+        assert (await anext(committed)).text == "a"
+        await committed.aclose()
+
+        assert source_closed
+
+    @pytest.mark.asyncio
+    async def test_accepts_custom_closable_iterator(self) -> None:
+        class CustomStream:
+            def __init__(self) -> None:
+                self.items = iter((_chunk("a"), _chunk("b")))
+                self.closed = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self) -> LLMResult:
+                try:
+                    return next(self.items)
+                except StopIteration as exc:
+                    raise StopAsyncIteration from exc
+
+            async def aclose(self) -> None:
+                self.closed = True
+
+        source = CustomStream()
+        committed = await _commit_stream(source)
+        assert (await anext(committed)).text == "a"
+        await committed.aclose()
+
+        assert source.closed
 
 
 def _fake_chat_response(

--- a/packages/lmi/tests/test_dispatch.py
+++ b/packages/lmi/tests/test_dispatch.py
@@ -8,7 +8,7 @@ network access. Unit-level tests exercise `_run_with_fallbacks` and
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -20,7 +20,7 @@ from litellm.types.utils import Message as LiteLLMMessage
 
 from lmi.config import LLMConfig, ModelSpec
 from lmi.exceptions import AllModelsExhaustedError, ModelRefusalError
-from lmi.llms import LiteLLMModel, _commit_stream
+from lmi.llms import ClosableAsyncIterator, LiteLLMModel, _commit_stream
 from lmi.types import LLMResult
 
 
@@ -188,7 +188,7 @@ class TestRunWithFallbacks:
 class TestCommitStream:
     @pytest.mark.asyncio
     async def test_replays_all_chunks(self) -> None:
-        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+        async def gen() -> ClosableAsyncIterator[LLMResult]:  # noqa: RUF029
             for chunk in ("a", "b", "c"):
                 yield _chunk(chunk)
 
@@ -198,7 +198,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_pre_first_chunk_error_propagates(self) -> None:
-        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+        async def gen() -> ClosableAsyncIterator[LLMResult]:  # noqa: RUF029
             raise litellm.RateLimitError(
                 message="pre-first-chunk", model=PRIMARY, llm_provider="openai"
             )
@@ -209,7 +209,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_empty_stream_raises_runtime_error(self) -> None:
-        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+        async def gen() -> ClosableAsyncIterator[LLMResult]:  # noqa: RUF029
             return
             yield _chunk("unreachable")  # type: ignore[unreachable]  # pragma: no cover
 
@@ -218,7 +218,7 @@ class TestCommitStream:
 
     @pytest.mark.asyncio
     async def test_mid_stream_error_surfaces_unmodified(self) -> None:
-        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+        async def gen() -> ClosableAsyncIterator[LLMResult]:  # noqa: RUF029
             yield _chunk("a")
             raise litellm.APIConnectionError(
                 message="mid-stream", model=PRIMARY, llm_provider="openai"
@@ -236,7 +236,7 @@ class TestCommitStream:
     async def test_closing_committed_stream_closes_source(self) -> None:
         source_closed = False
 
-        async def gen() -> AsyncGenerator[LLMResult]:  # noqa: RUF029
+        async def gen() -> ClosableAsyncIterator[LLMResult]:  # noqa: RUF029
             nonlocal source_closed
             try:
                 yield _chunk("a")


### PR DESCRIPTION
In a few places we are passing around async iterators that may or may not implement `aclose`. tighten this to specify that they do and add unconditional call to aclose after exit or cancellation. this allows more reliable stream interruption handling and lifecycle management in preparation for https://github.com/Future-House/ldp/pull/471