### PR TITLE
Test LDP and LMI across supported Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,11 +80,15 @@ jobs:
         run: uv sync
   test-ldp:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12, 3.13, 3.14]
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - run: uv sync
       - run: uv run pytest -n 16 --dist=loadfile tests
         env:
@@ -98,6 +102,9 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   test-lmi:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11, 3.12, 3.13, 3.14]
     steps:
       - uses: actions/checkout@v6
       - uses: google-github-actions/auth@v3
@@ -106,6 +113,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.0.0
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
       - run: uv sync
       - run: |
           uv run pytest -n 16 --dist=loadfile packages/lmi/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,9 +78,10 @@ jobs:
           enable-cache: true
       - name: Confirm dependency compilation
         run: uv sync
-  test-ldp:
+  test-ldp-matrix:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.11, 3.12, 3.13, 3.14]
     steps:
@@ -100,9 +101,16 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  test-lmi:
+  test-ldp:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: test-ldp-matrix
+    steps:
+      - run: test "${{ needs.test-ldp-matrix.result }}" = success
+  test-lmi-matrix:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.11, 3.12, 3.13, 3.14]
     steps:
@@ -120,3 +128,9 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  test-lmi:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: test-lmi-matrix
+    steps:
+      - run: test "${{ needs.test-lmi-matrix.result }}" = success


### PR DESCRIPTION
A recent commit caused a break in a dependent codebase in python 3.11 but did not get tested against that version in this repo's ci. add a matrix of python versions so we have more visibility into version-dependent issues before they break dependent code.