### PR TITLE
Hash ids to be response api compatible

### DIFF
--- a/packages/lmi/src/lmi/llms.py
+++ b/packages/lmi/src/lmi/llms.py
@@ -15,6 +15,7 @@ __all__ = [
 import asyncio
 import contextlib
 import functools
+import hashlib
 import json
 import logging
 from abc import ABC
@@ -95,6 +96,8 @@ from . import (
 
 logger = logging.getLogger(__name__)
 
+_RESPONSES_CALL_ID_MAX_LENGTH = 64
+
 
 def _convert_content_block_for_responses(block: dict[str, Any]) -> dict[str, Any]:
     """Convert a single Chat Completions content block to Responses API format.
@@ -139,7 +142,7 @@ def _convert_multimodal_content_for_responses(msg: Message) -> list[dict[str, An
 
 def _convert_to_responses_input(messages: list[Message]) -> list[dict[str, Any]]:
     """Convert aviary Messages to Responses API input format."""
-    result = []
+    result: list[dict[str, Any]] = []
     for msg in messages:
         if isinstance(msg, ToolResponseMessage):
             result.append({
@@ -175,6 +178,36 @@ def _convert_to_responses_input(messages: list[Message]) -> list[dict[str, Any]]
                 "role": msg.role,
                 "content": msg.content or "",
             })
+
+    function_call_ids: set[str] = {
+        cast(str, item["call_id"]) for item in result if item["type"] == "function_call"
+    }
+    function_call_output_ids: set[str] = {
+        cast(str, item["call_id"])
+        for item in result
+        if item["type"] == "function_call_output"
+    }
+    long_ids = {
+        call_id
+        for call_id in function_call_ids | function_call_output_ids
+        if len(call_id) > _RESPONSES_CALL_ID_MAX_LENGTH
+    }
+    unpaired_ids = long_ids - (function_call_ids & function_call_output_ids)
+    if unpaired_ids:
+        unpaired_id = min(unpaired_ids)
+        raise ValueError(
+            "Cannot normalize an overlong Responses API call_id unless both its "
+            f"function call and output are in the request: {unpaired_id!r}"
+        )
+
+    normalized_ids = {
+        call_id: hashlib.sha256(call_id.encode()).hexdigest() for call_id in long_ids
+    }
+    for item in result:
+        item_call_id = item.get("call_id")
+        if isinstance(item_call_id, str) and item_call_id in normalized_ids:
+            item["call_id"] = normalized_ids[item_call_id]
+
     return result
 
 

--- a/packages/lmi/tests/test_llms.py
+++ b/packages/lmi/tests/test_llms.py
@@ -1245,6 +1245,28 @@ async def test_gemini3_tool_patch(
 class TestResponsesAPI:
     """Tests for Responses API support (conversion functions, delta detection, stateful calls)."""
 
+    @staticmethod
+    def _tool_pair(call_id: str) -> list[Message]:
+        return [
+            ToolRequestMessage(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id=call_id,
+                        type="function",
+                        function={"name": "get_weather", "arguments": {"city": "NYC"}},
+                    )
+                ],
+            ),
+            ToolResponseMessage(
+                role="tool",
+                content="72°F",
+                tool_call_id=call_id,
+                name="get_weather",
+            ),
+        ]
+
     def test_extract_previous_response_id_none(self) -> None:
         msgs = [
             Message(content="hi", role="user"),
@@ -1411,6 +1433,42 @@ class TestResponsesAPI:
         assert result == [
             {"type": "function_call_output", "call_id": "call_1", "output": "72°F"},
         ]
+
+    def test_convert_to_responses_input_normalizes_long_paired_call_id(self) -> None:
+        long_id = "provider_call_" + "x" * 80
+
+        result = _convert_to_responses_input(self._tool_pair(long_id))
+
+        normalized_ids = [item["call_id"] for item in result]
+        assert len(set(normalized_ids)) == 1
+        assert len(normalized_ids[0]) <= 64
+        assert normalized_ids[0] != long_id
+
+    def test_long_call_id_normalization_is_deterministic_and_distinct(self) -> None:
+        first_id = "a" * 65
+        second_id = "b" * 65
+
+        first = _convert_to_responses_input(self._tool_pair(first_id))[0]["call_id"]
+        first_again = _convert_to_responses_input(self._tool_pair(first_id))[0][
+            "call_id"
+        ]
+        second = _convert_to_responses_input(self._tool_pair(second_id))[0]["call_id"]
+
+        assert first == first_again
+        assert first != second
+
+    def test_convert_to_responses_input_rejects_long_output_only_call_id(self) -> None:
+        msgs: list[Message] = [
+            ToolResponseMessage(
+                role="tool",
+                content="72°F",
+                tool_call_id="x" * 65,
+                name="get_weather",
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="both its function call and output"):
+            _convert_to_responses_input(msgs)
 
     def test_convert_tools_for_responses(self) -> None:
         tools = [


### PR DESCRIPTION
We are seeing some [failures in production](https://console.cloud.google.com/logs/query;cursorTimestamp=2026-08-29T04:00:19.815984576Z;duration=P7D;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22crow-prod-451317%22%0Aresource.labels.location%3D%22us-west2%22%0Aresource.labels.cluster_name%3D%22platform-cluster%22%0Aresource.labels.namespace_name%3D%22agent-sandbox-system%22%0Aseverity%3E%3DDEFAULT%0ASEARCH%2528%22aresponses%20attempt%20failed%20on%20%60openai%2Fgpt-5.6-sol%60%22%2529%0Atimestamp%3D%222026-08-29T04:00:19.815984576Z%22%0AinsertId%3D%22gt2k7zasl3s9turz%22;storageScope=project?project=crow-prod-451317) as a result of us sending ids to the responses API that breach the limits of the API. This change serialises the ids such that they are within the character limit of the api. I've tested this locally and it's working fine. I assume the long ids are coming from other models and we're seeing this now that we've swapped from ant to open for the orch

Offending ids: `call_4498671d257346d4baa6f58c1dbb__thought__ZTI0ODMwYTctNWNkNi00MmZlLTk5OGItZWU1MzllNzJiOWMz`